### PR TITLE
Linter for clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -33,7 +33,7 @@ BraceWrapping:
   SplitEmptyRecord: true
 BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeTernaryOperators: true
-BreakConstructorInitializers: BeforeColon
+BreakConstructorInitializers: BeforeComma
 BreakInheritanceList: BeforeColon
 ColumnLimit: 100
 CompactNamespaces: false

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,4 +1,4 @@
-name: clang-format
+name: Clang-Format
 
 on:
   push:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,19 @@
+name: clang-format
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: DoozyX/clang-format-lint-action@v0.16
+        with:
+          source: '.'
+          extensions: 'hpp,cpp'
+          clangFormatVersion: 16

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -12,8 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: DoozyX/clang-format-lint-action@v0.16
+      - uses: DoozyX/clang-format-lint-action@v0.14
         with:
           source: '.'
           extensions: 'hpp,cpp'
-          clangFormatVersion: 16
+          clangFormatVersion: 14

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ROSflight
 
-[![ROS2 CI](https://github.com/rosflight/rosflight/actions/workflows/ros2-ci.yml/badge.svg)](https://github.com/rosflight/rosflight/actions/workflows/ros2-ci.yml)
+[![ROS2 CI](https://github.com/rosflight/rosflight_ros_pkgs/actions/workflows/ros2-ci.yml/badge.svg)](https://github.com/rosflight/rosflight_ros_pkgs/actions/workflows/ros2-ci.yml) [![clang-format](https://github.com/rosflight/rosflight_ros_pkgs/actions/workflows/clang-format.yml/badge.svg)](https://github.com/rosflight/rosflight_ros_pkgs/actions/workflows/clang-format.yml) 
 
 This repository contains a ROS2 stack for interfacing with an autopilot running the ROSflight firmware.
 For more information on the ROSflight autopilot firmware stack, visit http://rosflight.org.

--- a/fix_code_style.sh
+++ b/fix_code_style.sh
@@ -8,7 +8,7 @@ cd $SCRIPTPATH
 # Find all files with ".hpp" or ".cpp" extensions in the current directory and subdirectories,
 # excluding certain paths (.rosflight_io/include/mavlink/v1.0/, ./rosflight_firmware/firmware/, and ./.git)
 find . -iname "*.hpp" -o -iname "*.cpp" | \
-egrep -v "^(.rosflight_io/include/mavlink/v1.0/|./rosflight_firmware/firmware/|./.git)" | \
+egrep -v "^(.rosflight_io/include/mavlink/v1.0/|./rosflight_sim/include/rosflight_sim/rosflight_firmware/|./.git)" | \
 
 # Format the files according to the rules specified in .clang-format
 xargs clang-format -i

--- a/rosflight_io/include/rosflight_io/mavrosflight/mavlink_comm.hpp
+++ b/rosflight_io/include/rosflight_io/mavrosflight/mavlink_comm.hpp
@@ -124,9 +124,14 @@ private:
     size_t len;
     size_t pos;
 
-    WriteBuffer() : len(0), pos(0) {}
+    WriteBuffer()
+        : len(0)
+        , pos(0)
+    {}
 
-    WriteBuffer(const uint8_t * buf, uint16_t len) : len(len), pos(0)
+    WriteBuffer(const uint8_t * buf, uint16_t len)
+        : len(len)
+        , pos(0)
     {
       assert(len <= MAVLINK_MAX_PACKET_LEN); //! \todo Do something less catastrophic here
       memcpy(data, buf, len);

--- a/rosflight_io/include/rosflight_io/mavrosflight/mavlink_comm.hpp
+++ b/rosflight_io/include/rosflight_io/mavrosflight/mavlink_comm.hpp
@@ -101,12 +101,12 @@ protected:
   virtual bool is_open() = 0;
   virtual void do_open() = 0;
   virtual void do_close() = 0;
-  virtual void do_async_read(
-    const boost::asio::mutable_buffers_1 & buffer,
-    boost::function<void(const boost::system::error_code &, size_t)> handler) = 0;
-  virtual void do_async_write(
-    const boost::asio::const_buffers_1 & buffer,
-    boost::function<void(const boost::system::error_code &, size_t)> handler) = 0;
+  virtual void
+  do_async_read(const boost::asio::mutable_buffers_1 & buffer,
+                boost::function<void(const boost::system::error_code &, size_t)> handler) = 0;
+  virtual void
+  do_async_write(const boost::asio::const_buffers_1 & buffer,
+                 boost::function<void(const boost::system::error_code &, size_t)> handler) = 0;
 
   boost::asio::io_service io_service_; //!< boost io service provider
 

--- a/rosflight_io/include/rosflight_io/mavrosflight/mavlink_serial.hpp
+++ b/rosflight_io/include/rosflight_io/mavrosflight/mavlink_serial.hpp
@@ -73,17 +73,17 @@ private:
   /**
    * \brief Initiate an asynchronous read operation
    */
-  void do_async_read(
-    const boost::asio::mutable_buffers_1 & buffer,
-    boost::function<void(const boost::system::error_code &, size_t)> handler) override;
+  void
+  do_async_read(const boost::asio::mutable_buffers_1 & buffer,
+                boost::function<void(const boost::system::error_code &, size_t)> handler) override;
 
   /**
    * \brief Initialize an asynchronous write operation
    * \param check_write_state If true, only start another write operation if a write sequence is not already running
    */
-  void do_async_write(
-    const boost::asio::const_buffers_1 & buffer,
-    boost::function<void(const boost::system::error_code &, size_t)> handler) override;
+  void
+  do_async_write(const boost::asio::const_buffers_1 & buffer,
+                 boost::function<void(const boost::system::error_code &, size_t)> handler) override;
 
   //===========================================================================
   // member variables

--- a/rosflight_io/include/rosflight_io/mavrosflight/mavlink_udp.hpp
+++ b/rosflight_io/include/rosflight_io/mavrosflight/mavlink_udp.hpp
@@ -72,12 +72,12 @@ private:
   bool is_open() override;
   void do_open() override;
   void do_close() override;
-  void do_async_read(
-    const boost::asio::mutable_buffers_1 & buffer,
-    boost::function<void(const boost::system::error_code &, size_t)> handler) override;
-  void do_async_write(
-    const boost::asio::const_buffers_1 & buffer,
-    boost::function<void(const boost::system::error_code &, size_t)> handler) override;
+  void
+  do_async_read(const boost::asio::mutable_buffers_1 & buffer,
+                boost::function<void(const boost::system::error_code &, size_t)> handler) override;
+  void
+  do_async_write(const boost::asio::const_buffers_1 & buffer,
+                 boost::function<void(const boost::system::error_code &, size_t)> handler) override;
 
   //===========================================================================
   // member variables

--- a/rosflight_io/include/rosflight_io/mavrosflight/serial_exception.hpp
+++ b/rosflight_io/include/rosflight_io/mavrosflight/serial_exception.hpp
@@ -57,7 +57,9 @@ public:
 
   explicit SerialException(const boost::system::system_error & err) { init(err.what()); }
 
-  SerialException(const SerialException & other) : what_(other.what_) {}
+  SerialException(const SerialException & other)
+      : what_(other.what_)
+  {}
 
   ~SerialException() noexcept override = default;
 

--- a/rosflight_io/src/mag_cal.cpp
+++ b/rosflight_io/src/mag_cal.cpp
@@ -44,8 +44,12 @@
 namespace rosflight_io
 {
 CalibrateMag::CalibrateMag()
-    : Node("calibrate_accel_temp"), reference_field_strength_(1.0), calibrating_(false),
-      first_time_(true), start_time_(0), measurement_throttle_(0)
+    : Node("calibrate_accel_temp")
+    , reference_field_strength_(1.0)
+    , calibrating_(false)
+    , first_time_(true)
+    , start_time_(0)
+    , measurement_throttle_(0)
 {
   A_ = Eigen::MatrixXd::Zero(3, 3);
   b_ = Eigen::MatrixXd::Zero(3, 1);

--- a/rosflight_io/src/mavrosflight/mavlink_comm.cpp
+++ b/rosflight_io/src/mavrosflight/mavlink_comm.cpp
@@ -41,7 +41,11 @@ namespace mavrosflight
 using boost::asio::serial_port_base;
 
 MavlinkComm::MavlinkComm()
-    : io_service_(), read_buf_raw_(), msg_in_(), status_in_(), write_in_progress_(false)
+    : io_service_()
+    , read_buf_raw_()
+    , msg_in_()
+    , status_in_()
+    , write_in_progress_(false)
 {}
 
 MavlinkComm::~MavlinkComm() = default;

--- a/rosflight_io/src/mavrosflight/mavlink_serial.cpp
+++ b/rosflight_io/src/mavrosflight/mavlink_serial.cpp
@@ -42,7 +42,10 @@ namespace mavrosflight
 using boost::asio::serial_port_base;
 
 MavlinkSerial::MavlinkSerial(std::string port, int baud_rate)
-    : MavlinkComm(), serial_port_(io_service_), port_(std::move(port)), baud_rate_(baud_rate)
+    : MavlinkComm()
+    , serial_port_(io_service_)
+    , port_(std::move(port))
+    , baud_rate_(baud_rate)
 {}
 
 MavlinkSerial::~MavlinkSerial() { MavlinkSerial::do_close(); }

--- a/rosflight_io/src/mavrosflight/mavlink_udp.cpp
+++ b/rosflight_io/src/mavrosflight/mavlink_udp.cpp
@@ -45,8 +45,12 @@ using boost::asio::serial_port_base;
 
 MavlinkUDP::MavlinkUDP(std::string bind_host, uint16_t bind_port, std::string remote_host,
                        uint16_t remote_port)
-    : MavlinkComm(), bind_host_(std::move(bind_host)), bind_port_(bind_port),
-      remote_host_(std::move(remote_host)), remote_port_(remote_port), socket_(io_service_)
+    : MavlinkComm()
+    , bind_host_(std::move(bind_host))
+    , bind_port_(bind_port)
+    , remote_host_(std::move(remote_host))
+    , remote_port_(remote_port)
+    , socket_(io_service_)
 {}
 
 MavlinkUDP::~MavlinkUDP() { MavlinkUDP::do_close(); }

--- a/rosflight_io/src/mavrosflight/mavrosflight.cpp
+++ b/rosflight_io/src/mavrosflight/mavrosflight.cpp
@@ -41,7 +41,9 @@ namespace mavrosflight
 using boost::asio::serial_port_base;
 
 MavROSflight::MavROSflight(MavlinkComm & mavlink_comm, rclcpp::Node * const node)
-    : comm(mavlink_comm), param(&comm, node), time(&comm, node)
+    : comm(mavlink_comm)
+    , param(&comm, node)
+    , time(&comm, node)
 {
   comm.open();
 }

--- a/rosflight_io/src/mavrosflight/param.cpp
+++ b/rosflight_io/src/mavrosflight/param.cpp
@@ -38,12 +38,18 @@
 
 namespace mavrosflight
 {
-Param::Param() : value_(0), new_value_(0), expected_raw_value_(0)
+Param::Param()
+    : value_(0)
+    , new_value_(0)
+    , expected_raw_value_(0)
 {
   init("", -1, MAV_PARAM_TYPE_ENUM_END, 0.0f);
 }
 
-Param::Param(mavlink_param_value_t msg) : value_(0), new_value_(0), expected_raw_value_(0)
+Param::Param(mavlink_param_value_t msg)
+    : value_(0)
+    , new_value_(0)
+    , expected_raw_value_(0)
 {
   char name[MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN + 1];
   memcpy(name, msg.param_id, MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN);
@@ -53,7 +59,9 @@ Param::Param(mavlink_param_value_t msg) : value_(0), new_value_(0), expected_raw
 }
 
 Param::Param(std::string name, int index, MAV_PARAM_TYPE type, float raw_value)
-    : value_(0), new_value_(0), expected_raw_value_(0)
+    : value_(0)
+    , new_value_(0)
+    , expected_raw_value_(0)
 {
   init(std::move(name), index, type, raw_value);
 }

--- a/rosflight_io/src/mavrosflight/param_manager.cpp
+++ b/rosflight_io/src/mavrosflight/param_manager.cpp
@@ -43,9 +43,16 @@
 namespace mavrosflight
 {
 ParamManager::ParamManager(MavlinkComm * const comm, rclcpp::Node * const node)
-    : node_(node), comm_(comm), unsaved_changes_(false), write_request_in_progress_(false),
-      first_param_received_(false), num_params_(0), received_count_(0), received_(nullptr),
-      got_all_params_(false), param_set_in_progress_(false)
+    : node_(node)
+    , comm_(comm)
+    , unsaved_changes_(false)
+    , write_request_in_progress_(false)
+    , first_param_received_(false)
+    , num_params_(0)
+    , received_count_(0)
+    , received_(nullptr)
+    , got_all_params_(false)
+    , param_set_in_progress_(false)
 {
   comm_->register_mavlink_listener(this);
 

--- a/rosflight_io/src/mavrosflight/time_manager.cpp
+++ b/rosflight_io/src/mavrosflight/time_manager.cpp
@@ -40,7 +40,11 @@
 namespace mavrosflight
 {
 TimeManager::TimeManager(MavlinkComm * const comm, rclcpp::Node * const node)
-    : comm_(comm), node_(node), offset_alpha_(0.95), offset_ns_(0), initialized_(false)
+    : comm_(comm)
+    , node_(node)
+    , offset_alpha_(0.95)
+    , offset_ns_(0)
+    , initialized_(false)
 {
   comm_->register_mavlink_listener(this);
   time_sync_timer_ = node_->create_wall_timer(
@@ -64,8 +68,7 @@ void TimeManager::handle_mavlink_message(const mavlink_message_t & msg)
 
       // if difference > 10ms, use it directly
       if (!initialized_ || (offset_ns_ - offset_ns) > std::chrono::milliseconds(10)
-        || (offset_ns_ - offset_ns) < std::chrono::milliseconds(-10))
-      {
+          || (offset_ns_ - offset_ns) < std::chrono::milliseconds(-10)) {
         RCLCPP_INFO(node_->get_logger(), "Detected time offset of %0.3f s.",
                     abs(std::chrono::duration<double>(offset_ns_ - offset_ns).count()));
         RCLCPP_DEBUG(node_->get_logger(), "FCU time: %0.3f, System time: %0.3f", tsync.tc1 * 1e-9,

--- a/rosflight_io/src/rosflight_io.cpp
+++ b/rosflight_io/src/rosflight_io.cpp
@@ -55,7 +55,9 @@
 
 namespace rosflight_io
 {
-rosflightIO::rosflightIO() : Node("rosflight_io"), prev_status_()
+rosflightIO::rosflightIO()
+    : Node("rosflight_io")
+    , prev_status_()
 {
   command_sub_ = this->create_subscription<rosflight_msgs::msg::Command>(
     "command", 1, std::bind(&rosflightIO::commandCallback, this, std::placeholders::_1));

--- a/rosflight_sim/include/rosflight_sim/sil_board.hpp
+++ b/rosflight_sim/include/rosflight_sim/sil_board.hpp
@@ -164,7 +164,7 @@ public:
   /**
    * @brief Function required to be overridden, but not used by sim.
    */
-  void board_reset(bool bootloader) override {};
+  void board_reset(bool bootloader) override{};
 
   // clock
   /**
@@ -182,7 +182,7 @@ public:
   /**
    * @brief Function required to be overridden, but not used by sim.
    */
-  void clock_delay(uint32_t milliseconds) override {};
+  void clock_delay(uint32_t milliseconds) override{};
 
   // serial
   /**
@@ -247,7 +247,7 @@ public:
   /**
    * @brief Function required to be overridden, but not used by sim.
    */
-  void mag_update() override {};
+  void mag_update() override{};
 
   /**
    * @brief Function used to check if a barometer is present. Currently returns true.
@@ -266,7 +266,7 @@ public:
   /**
    * @brief Function required to be overridden, but not used by sim.
    */
-  void baro_update() override {};
+  void baro_update() override{};
 
   /**
    * @brief Checks if a pitot tube sensor is present. Returns true if sim is a fixedwing sim.
@@ -285,7 +285,7 @@ public:
   /**
    * @brief Function required to be overridden, but not used by sim.
    */
-  void diff_pressure_update() override {};
+  void diff_pressure_update() override{};
 
   /**
    * @brief Function used to see if a sonar altitude sensor is present. Currently returns true.
@@ -305,7 +305,7 @@ public:
   /**
    * @brief Function required to be overridden, but not used by sim.
    */
-  void sonar_update() override {};
+  void sonar_update() override{};
 
   // PWM
   // TODO make these deal in normalized (-1 to 1 or 0 to 1) values (not pwm-specific)
@@ -344,7 +344,7 @@ public:
   /**
    * @brief Function required to be overridden, but not used by sim.
    */
-  void rc_init(rc_type_t rc_type) override {};
+  void rc_init(rc_type_t rc_type) override{};
   /**
    * @brief Function used to check if RC connection is present. Currently returns false if anything
    * is ever published on RC.
@@ -357,7 +357,7 @@ public:
   /**
    * @brief Function required to be overridden, but not used by sim.
    */
-  void memory_init() override {};
+  void memory_init() override{};
   /**
    * @brief Reads data from memory file.
    *
@@ -379,34 +379,34 @@ public:
   /**
    * @brief Function required to be overridden, but not used by sim.
    */
-  void led0_on() override {};
+  void led0_on() override{};
   /**
    * @brief Function required to be overridden, but not used by sim.
    */
-  void led0_off() override {};
+  void led0_off() override{};
   /**
    * @brief Function required to be overridden, but not used by sim.
    */
-  void led0_toggle() override {};
+  void led0_toggle() override{};
 
   /**
    * @brief Function required to be overridden, but not used by sim.
    */
-  void led1_on() override {};
+  void led1_on() override{};
   /**
    * @brief Function required to be overridden, but not used by sim.
    */
-  void led1_off() override {};
+  void led1_off() override{};
   /**
    * @brief Function required to be overridden, but not used by sim.
    */
-  void led1_toggle() override {};
+  void led1_toggle() override{};
 
   // Backup Memory
   /**
    * @brief Function required to be overridden, but not used by sim.
    */
-  void backup_memory_init() override {};
+  void backup_memory_init() override{};
   /**
    * @brief Reads data from backup memory object.
    *
@@ -440,7 +440,7 @@ public:
   /**
    * @brief Function required to be overridden, but not used by sim.
    */
-  void gnss_update() override {};
+  void gnss_update() override{};
 
   /**
    * @brief Generates GNSS data based on Gazebo truth and noise/bias parameters.

--- a/rosflight_sim/include/rosflight_sim/sil_board.hpp
+++ b/rosflight_sim/include/rosflight_sim/sil_board.hpp
@@ -48,8 +48,8 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rosflight_msgs/msg/rc_raw.hpp>
 
-#include <rosflight_sim/udp_board.hpp>
 #include <rosflight_sim/gz_compat.hpp>
+#include <rosflight_sim/udp_board.hpp>
 
 namespace rosflight_sim
 {

--- a/rosflight_sim/include/rosflight_sim/udp_board.hpp
+++ b/rosflight_sim/include/rosflight_sim/udp_board.hpp
@@ -71,9 +71,14 @@ private:
     size_t len;
     size_t pos;
 
-    Buffer() : len(0), pos(0) {}
+    Buffer()
+        : len(0)
+        , pos(0)
+    {}
 
-    Buffer(const uint8_t * src, size_t length) : len(length), pos(0)
+    Buffer(const uint8_t * src, size_t length)
+        : len(length)
+        , pos(0)
     {
       assert(length <= MAVLINK_MAX_PACKET_LEN); //! \todo Do something less catastrophic here
       memcpy(data, src, length);

--- a/rosflight_sim/src/multirotor_forces_and_moments.cpp
+++ b/rosflight_sim/src/multirotor_forces_and_moments.cpp
@@ -37,7 +37,10 @@
 namespace rosflight_sim
 {
 Multirotor::Multirotor(rclcpp::Node::SharedPtr node)
-    : node_(std::move(node)), num_rotors_(0), linear_mu_(0), angular_mu_(0)
+    : node_(std::move(node))
+    , num_rotors_(0)
+    , linear_mu_(0)
+    , angular_mu_(0)
 {
   declare_multirotor_params();
 

--- a/rosflight_sim/src/rosflight_sil.cpp
+++ b/rosflight_sim/src/rosflight_sil.cpp
@@ -43,7 +43,10 @@
 namespace rosflight_sim
 {
 ROSflightSIL::ROSflightSIL()
-    : gazebo::ModelPlugin(), comm_(board_), firmware_(board_, comm_), mav_dynamics_()
+    : gazebo::ModelPlugin()
+    , comm_(board_)
+    , firmware_(board_, comm_)
+    , mav_dynamics_()
 {}
 
 ROSflightSIL::~ROSflightSIL() { GZ_COMPAT_DISCONNECT_WORLD_UPDATE_BEGIN(updateConnection_); }

--- a/rosflight_sim/src/sil_board.cpp
+++ b/rosflight_sim/src/sil_board.cpp
@@ -40,8 +40,8 @@
 namespace rosflight_sim
 {
 SILBoard::SILBoard()
-    : UDPBoard(),
-      random_generator_(std::chrono::system_clock::now().time_since_epoch().count())
+    : UDPBoard()
+    , random_generator_(std::chrono::system_clock::now().time_since_epoch().count())
 {}
 
 void SILBoard::init_board() { boot_time_ = GZ_COMPAT_GET_SIM_TIME(world_); }

--- a/rosflight_sim/src/udp_board.cpp
+++ b/rosflight_sim/src/udp_board.cpp
@@ -34,8 +34,8 @@
  * \author Daniel Koch
  */
 
-#include <iostream>
 #include "rosflight_sim/udp_board.hpp"
+#include <iostream>
 
 using boost::asio::ip::udp;
 
@@ -43,8 +43,13 @@ namespace rosflight_sim
 {
 UDPBoard::UDPBoard(std::string bind_host, uint16_t bind_port, std::string remote_host,
                    uint16_t remote_port)
-    : bind_host_(std::move(bind_host)), bind_port_(bind_port), remote_host_(std::move(remote_host)),
-      remote_port_(remote_port), io_service_(), socket_(io_service_), write_in_progress_(false)
+    : bind_host_(std::move(bind_host))
+    , bind_port_(bind_port)
+    , remote_host_(std::move(remote_host))
+    , remote_port_(remote_port)
+    , io_service_()
+    , socket_(io_service_)
+    , write_in_progress_(false)
 {}
 
 UDPBoard::~UDPBoard()

--- a/rosflight_utils/src/viz.cpp
+++ b/rosflight_utils/src/viz.cpp
@@ -36,7 +36,8 @@
 
 namespace rosflight_utils
 {
-Viz::Viz() : Node("viz_node")
+Viz::Viz()
+    : Node("viz_node")
 {
   // retrieve params
 


### PR DESCRIPTION
To help maintain a more consistent coding style, I've added an automatic clang-format compliance check, similar to what is found in the rosflight_firmware repo. I've also tweaked the clang-format file slightly, to improve the readability of class initialization lists.