### PR TITLE
Rqt plotting gui

### DIFF
--- a/rosflight_rqt_plugins/package.xml
+++ b/rosflight_rqt_plugins/package.xml
@@ -9,6 +9,8 @@
   <exec_depend>python_qt_binding</exec_depend>
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
+  <exec_depend>python3-matplotlib</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/rosflight_rqt_plugins/resources/param_tuning.ui
+++ b/rosflight_rqt_plugins/resources/param_tuning.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1000</width>
+    <width>1500</width>
     <height>500</height>
    </rect>
   </property>
@@ -64,7 +64,65 @@
      </property>
      <widget class="QTableView" name="param_table_view"/>
      <widget class="QWidget" name="verticalLayoutWidget">
-      <layout class="QVBoxLayout" name="plot_layout"/>
+      <layout class="QVBoxLayout" name="plot_layout">
+       <item>
+        <layout class="QHBoxLayout" name="plot_button_layout">
+         <item>
+          <spacer name="horizontal_spacer_1">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="time_axis_label">
+           <property name="text">
+            <string>Time Axis Setting - Duration:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="time_duration_spin_box">
+           <property name="minimum">
+            <number>5</number>
+           </property>
+           <property name="maximum">
+            <number>1000</number>
+           </property>
+           <property name="singleStep">
+            <number>5</number>
+           </property>
+           <property name="stepType">
+            <enum>QAbstractSpinBox::DefaultStepType</enum>
+           </property>
+           <property name="value">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="lock_plot_check_box">
+           <property name="text">
+            <string>Lock Axis</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="reset_plot_button">
+           <property name="text">
+            <string>Reset Lock</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
      </widget>
     </widget>
    </item>

--- a/rosflight_rqt_plugins/resources/param_tuning.ui
+++ b/rosflight_rqt_plugins/resources/param_tuning.ui
@@ -26,7 +26,7 @@
    <item row="0" column="0">
     <layout class="QVBoxLayout" name="mainVerticalLayout" stretch="0,0">
      <property name="spacing">
-      <number>12</number>
+      <number>5</number>
      </property>
      <property name="sizeConstraint">
       <enum>QLayout::SetDefaultConstraint</enum>

--- a/rosflight_rqt_plugins/resources/param_tuning.ui
+++ b/rosflight_rqt_plugins/resources/param_tuning.ui
@@ -107,16 +107,16 @@
           </widget>
          </item>
          <item>
-          <widget class="QCheckBox" name="lock_plot_check_box">
+          <widget class="QCheckBox" name="pause_plot_check_box">
            <property name="text">
-            <string>Lock Axis</string>
+            <string>Pause Scrolling</string>
            </property>
           </widget>
          </item>
          <item>
           <widget class="QPushButton" name="reset_plot_button">
            <property name="text">
-            <string>Reset Lock</string>
+            <string>Reset</string>
            </property>
           </widget>
          </item>

--- a/rosflight_rqt_plugins/resources/param_tuning.ui
+++ b/rosflight_rqt_plugins/resources/param_tuning.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>ParamTuning</class>
- <widget class="QWidget" name="ParamTuning">
+ <class>param_tuning</class>
+ <widget class="QWidget" name="param_tuning">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -24,12 +24,12 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="buttonHorizontalLayout">
+    <layout class="QHBoxLayout" name="param_button_layout">
      <item>
-      <widget class="QComboBox" name="groupSelection"/>
+      <widget class="QComboBox" name="group_selection"/>
      </item>
      <item>
-      <spacer name="horizontalSpacer">
+      <spacer name="horizontal_spacer_0">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -42,14 +42,14 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="refreshButton">
+      <widget class="QPushButton" name="refresh_button">
        <property name="text">
         <string>Refresh</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="saveButton">
+      <widget class="QPushButton" name="save_button">
        <property name="text">
         <string>Save to file</string>
        </property>
@@ -62,9 +62,9 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <widget class="QTableView" name="paramTableView"/>
+     <widget class="QTableView" name="param_table_view"/>
      <widget class="QWidget" name="verticalLayoutWidget">
-      <layout class="QVBoxLayout" name="plotLayout"/>
+      <layout class="QVBoxLayout" name="plot_layout"/>
      </widget>
     </widget>
    </item>

--- a/rosflight_rqt_plugins/resources/param_tuning.ui
+++ b/rosflight_rqt_plugins/resources/param_tuning.ui
@@ -83,7 +83,7 @@
          <item>
           <widget class="QLabel" name="time_axis_label">
            <property name="text">
-            <string>Time Axis Setting - Duration:</string>
+            <string>Time Axis Duration (s):</string>
            </property>
           </widget>
          </item>
@@ -109,7 +109,7 @@
          <item>
           <widget class="QCheckBox" name="pause_plot_check_box">
            <property name="text">
-            <string>Pause Scrolling</string>
+            <string>Pause Plotting</string>
            </property>
           </widget>
          </item>

--- a/rosflight_rqt_plugins/resources/param_tuning.ui
+++ b/rosflight_rqt_plugins/resources/param_tuning.ui
@@ -83,7 +83,7 @@
          <item>
           <widget class="QLabel" name="time_axis_label">
            <property name="text">
-            <string>Time Axis Duration (s):</string>
+            <string>Time axis duration (s):</string>
            </property>
           </widget>
          </item>
@@ -108,15 +108,11 @@
          </item>
          <item>
           <widget class="QCheckBox" name="pause_plot_check_box">
-           <property name="text">
-            <string>Pause Plotting</string>
+           <property name="layoutDirection">
+            <enum>Qt::RightToLeft</enum>
            </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="reset_plot_button">
            <property name="text">
-            <string>Reset</string>
+            <string>Pause plotting</string>
            </property>
           </widget>
          </item>

--- a/rosflight_rqt_plugins/resources/param_tuning.ui
+++ b/rosflight_rqt_plugins/resources/param_tuning.ui
@@ -102,7 +102,7 @@
             <enum>QAbstractSpinBox::DefaultStepType</enum>
            </property>
            <property name="value">
-            <number>5</number>
+            <number>20</number>
            </property>
           </widget>
          </item>

--- a/rosflight_rqt_plugins/resources/param_tuning.ui
+++ b/rosflight_rqt_plugins/resources/param_tuning.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1178</width>
-    <height>605</height>
+    <width>1000</width>
+    <height>500</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -22,65 +22,51 @@
   <property name="autoFillBackground">
    <bool>false</bool>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <layout class="QVBoxLayout" name="mainVerticalLayout" stretch="0,0">
-     <property name="spacing">
-      <number>5</number>
-     </property>
-     <property name="sizeConstraint">
-      <enum>QLayout::SetDefaultConstraint</enum>
-     </property>
-     <property name="leftMargin">
-      <number>5</number>
-     </property>
-     <property name="topMargin">
-      <number>5</number>
-     </property>
-     <property name="rightMargin">
-      <number>5</number>
-     </property>
-     <property name="bottomMargin">
-      <number>5</number>
-     </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="buttonHorizontalLayout">
      <item>
-      <layout class="QHBoxLayout" name="buttonHorizontalLayout">
-       <item>
-        <widget class="QComboBox" name="groupSelection"/>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QPushButton" name="refreshButton">
-         <property name="text">
-          <string>Refresh</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="saveButton">
-         <property name="text">
-          <string>Save to file</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
+      <widget class="QComboBox" name="groupSelection"/>
      </item>
      <item>
-      <widget class="QTableView" name="paramTableView"/>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="refreshButton">
+       <property name="text">
+        <string>Refresh</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="saveButton">
+       <property name="text">
+        <string>Save to file</string>
+       </property>
+      </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="QTableView" name="paramTableView"/>
+     <widget class="QWidget" name="verticalLayoutWidget">
+      <layout class="QVBoxLayout" name="plotLayout"/>
+     </widget>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/rosflight_rqt_plugins/resources/param_tuning.ui
+++ b/rosflight_rqt_plugins/resources/param_tuning.ui
@@ -83,7 +83,7 @@
          <item>
           <widget class="QLabel" name="time_axis_label">
            <property name="text">
-            <string>Time axis duration (s):</string>
+            <string>Time axis duration:</string>
            </property>
           </widget>
          </item>

--- a/rosflight_rqt_plugins/resources/param_tuning_example_config.yaml
+++ b/rosflight_rqt_plugins/resources/param_tuning_example_config.yaml
@@ -8,12 +8,12 @@
 #       description: '{Parameter description}'
 #       scale: {Scale factor to use with parameters}  (optional, default is 1.0)
 #     ...
-#   plot_axis_label: '{Y Axis Label}'  (x axis is always 'Time (s)')
 #   plot_topics: (optional, include if you want to plot data)
 #     {Plot name}:
 #       topic: '/{ROS_topic_name}/{field_name}'
 #       scale: {Scale factor to use with data}  (optional, default is 1.0)
 #     ...
+#   plot_axis_label: '{Y Axis Label}'  (x axis is always 'Time (s)')
 # ...
 
 
@@ -24,7 +24,6 @@ Roll Angle:
       description: 'Roll angle P gain'
     r_kd:
       description: 'Roll angle D gain'
-  plot_axis_label: 'Roll angle (deg)'
   plot_topics:
     Roll Command:
       topic: '/controller_internals/phi_c'
@@ -32,6 +31,7 @@ Roll Angle:
     Roll Estimate:
       topic: '/estimated_state/phi'
       scale: 57.2957795131
+  plot_axis_label: 'Roll angle (deg)'
 
 Pitch Angle:
   node: '/autopilot'
@@ -40,7 +40,6 @@ Pitch Angle:
       description: 'Pitch angle P gain'
     p_kd:
       description:  'Pitch angle D gain'
-  plot_axis_label: 'Pitch angle (deg)'
   plot_topics:
     Pitch Command:
       topic: '/controller_internals/theta_c'
@@ -48,6 +47,7 @@ Pitch Angle:
     Pitch Estimate:
       topic: '/estimated_state/theta'
       scale: 57.2957795131
+  plot_axis_label: 'Pitch angle (deg)'
 
 Airspeed:
   node: '/autopilot'
@@ -56,12 +56,12 @@ Airspeed:
       description:  'Airspeed P gain'
     a_t_ki:
       description:  'Airspeed I gain'
-  plot_axis_label: 'Airspeed (m/s)'
   plot_topics:
     Airspeed Command:
       topic: '/controller_command/va_c'
     Airspeed Estimate:
       topic: '/estimated_state/va'
+  plot_axis_label: 'Airspeed (m/s)'
 
 Course:
   node: '/autopilot'
@@ -70,7 +70,6 @@ Course:
       description:  'Course P gain'
     c_ki:
       description: 'Course I gain'
-  plot_axis_label: 'Course (deg)'
   plot_topics:
     Course Command:
       topic: '/controller_command/chi_c'
@@ -78,6 +77,7 @@ Course:
     Course Estimate:
       topic: '/estimated_state/chi'
       scale: 57.2957795131
+  plot_axis_label: 'Course (deg)'
 
 Altitude:
   node: '/autopilot'
@@ -86,13 +86,13 @@ Altitude:
       description:  'Altitude P gain'
     a_ki:
       description: 'Altitude I gain'
-  plot_axis_label: 'Altitude (m)'
   plot_topics:
     Altitude Command:
       topic: '/controller_command/h_c'
     Altitude Estimate:
       topic: '/estimated_state/position[2]'
       scale: -1.0
+  plot_axis_label: 'Altitude (m)'
 
 Line Following:
   node: '/path_follower'

--- a/rosflight_rqt_plugins/resources/param_tuning_example_config.yaml
+++ b/rosflight_rqt_plugins/resources/param_tuning_example_config.yaml
@@ -8,9 +8,7 @@
 #       description: '{Parameter Description}'
 #       scale: {Scale Factor to use with parameters}  (optional, default is 1.0)
 #     ...
-#   plot_axes:
-#     y_label: '{Y Axis Label}'  (x_axis is always 'Time (s)')
-#     y_scale: {Scale Factor to use with plot}  (optional, default is 1.0)
+#   plot_axis_label: '{Y Axis Label}'  (x axis is always 'Time (s)')
 #   plot_topics: (optional, include if you want to plot data)
 #     {Plot Name}: '/{ROS_topic_name}/{field_name}'
 #     ...
@@ -21,12 +19,10 @@ Roll Angle:
   node: '/autopilot'
   params:
     r_kp:
-      description: 'Roll Angle P Gain'
+      description: 'Roll angle P gain'
     r_kd:
-      description: 'Roll Angle D Gain'
-  plot_axes:
-    y_label: 'Roll angle (deg)'
-    y_scale: 57.2957795131
+      description: 'Roll angle D gain'
+  plot_axis_label: 'Roll angle (deg)'
   plot_topics:
     Roll Command: '/controller_internals/phi_c'
     Roll Estimate: '/estimated_state/phi'
@@ -35,12 +31,10 @@ Pitch Angle:
   node: '/autopilot'
   params:
     p_kp:
-      description: 'Pitch Angle P Gain'
+      description: 'Pitch angle P gain'
     p_kd:
-      description:  'Pitch Angle D Gain'
-  plot_axes:
-    y_label: 'Pitch angle (deg)'
-    y_scale: 57.2957795131
+      description:  'Pitch angle D gain'
+  plot_axis_label: 'Pitch angle (deg)'
   plot_topics:
     Pitch Command: '/controller_internals/theta_c'
     Pitch Estimate: '/estimated_state/theta'
@@ -49,11 +43,10 @@ Airspeed:
   node: '/autopilot'
   params:
     a_t_kp:
-      description:  'Airspeed P Gain'
+      description:  'Airspeed P gain'
     a_t_ki:
-      description:  'Airspeed I Gain'
-  plot_axes:
-    y_label: 'Airspeed (m/s)'
+      description:  'Airspeed I gain'
+  plot_axis_label: 'Airspeed (m/s)'
   plot_topics:
     Airspeed Command: '/controller_command/va_c'
     Airspeed Estimate: '/estimated_state/va'
@@ -62,12 +55,10 @@ Course:
   node: '/autopilot'
   params:
     c_kp:
-      description:  'Course P Gain'
+      description:  'Course P gain'
     c_ki:
-      description: 'Course I Gain'
-  plot_axes:
-    y_label: 'Course (deg)'
-    y_scale: 57.2957795131
+      description: 'Course I gain'
+  plot_axis_label: 'Course (deg)'
   plot_topics:
     Course Command: '/controller_command/chi_c'
     Course Estimate: '/estimated_state/chi'
@@ -76,11 +67,10 @@ Altitude:
   node: '/autopilot'
   params:
     a_kp:
-      description:  'Altitude P Gain'
+      description:  'Altitude P gain'
     a_ki:
-      description: 'Altitude I Gain'
-  plot_axes:
-    y_label: 'Altitude (m)'
+      description: 'Altitude I gain'
+  plot_axis_label: 'Altitude (m)'
   plot_topics:
     Altitude Command: '/controller_command/h_c'
     Altitude Estimate: '/estimated_state/position[2]'
@@ -89,13 +79,13 @@ Line Following:
   node: '/path_follower'
   params:
     k_path:
-      description:  'Line Following K Gain'
+      description:  'Line following K gain'
     chi_infty:
-      description:  'Max Approach Angle (degrees)'
+      description:  'Max approach angle (deg)'
       scale: 57.2957795131
 
 Orbit Following:
   node: '/path_follower'
   params:
     k_orbit:
-      description:  'Orbit Following K Gain'
+      description:  'Orbit following K gain'

--- a/rosflight_rqt_plugins/resources/param_tuning_example_config.yaml
+++ b/rosflight_rqt_plugins/resources/param_tuning_example_config.yaml
@@ -6,7 +6,7 @@
 #   params:
 #     {param_name}:
 #       description: '{Parameter Description}'
-#       scale: {Scale Factor to use with GUI}  (optional, default is 1.0)
+#       scale: {Scale Factor to use with parameters}  (optional, default is 1.0)
 #     ...
 #   plot_axes:
 #     y_label: '{Y Axis Label}'  (x_axis is always 'Time (s)')
@@ -83,7 +83,7 @@ Altitude:
     y_label: 'Altitude (m)'
   plot_topics:
     Altitude Command: '/controller_command/h_c'
-    Altitude Estimate: '/estimated_state/h'
+#    Altitude Estimate: '/estimated_state/position[2]'
 
 Line Following:
   node: '/path_follower'

--- a/rosflight_rqt_plugins/resources/param_tuning_example_config.yaml
+++ b/rosflight_rqt_plugins/resources/param_tuning_example_config.yaml
@@ -5,12 +5,14 @@
 #   node: '/{ROS_node_name}'
 #   params:
 #     {param_name}:
-#       description: '{Parameter Description}'
-#       scale: {Scale Factor to use with parameters}  (optional, default is 1.0)
+#       description: '{Parameter description}'
+#       scale: {Scale factor to use with parameters}  (optional, default is 1.0)
 #     ...
 #   plot_axis_label: '{Y Axis Label}'  (x axis is always 'Time (s)')
 #   plot_topics: (optional, include if you want to plot data)
-#     {Plot Name}: '/{ROS_topic_name}/{field_name}'
+#     {Plot name}:
+#       topic: '/{ROS_topic_name}/{field_name}'
+#       scale: {Scale factor to use with data}  (optional, default is 1.0)
 #     ...
 # ...
 
@@ -24,8 +26,12 @@ Roll Angle:
       description: 'Roll angle D gain'
   plot_axis_label: 'Roll angle (deg)'
   plot_topics:
-    Roll Command: '/controller_internals/phi_c'
-    Roll Estimate: '/estimated_state/phi'
+    Roll Command:
+      topic: '/controller_internals/phi_c'
+      scale: 57.2957795131
+    Roll Estimate:
+      topic: '/estimated_state/phi'
+      scale: 57.2957795131
 
 Pitch Angle:
   node: '/autopilot'
@@ -36,8 +42,12 @@ Pitch Angle:
       description:  'Pitch angle D gain'
   plot_axis_label: 'Pitch angle (deg)'
   plot_topics:
-    Pitch Command: '/controller_internals/theta_c'
-    Pitch Estimate: '/estimated_state/theta'
+    Pitch Command:
+      topic: '/controller_internals/theta_c'
+      scale: 57.2957795131
+    Pitch Estimate:
+      topic: '/estimated_state/theta'
+      scale: 57.2957795131
 
 Airspeed:
   node: '/autopilot'
@@ -48,8 +58,10 @@ Airspeed:
       description:  'Airspeed I gain'
   plot_axis_label: 'Airspeed (m/s)'
   plot_topics:
-    Airspeed Command: '/controller_command/va_c'
-    Airspeed Estimate: '/estimated_state/va'
+    Airspeed Command:
+      topic: '/controller_command/va_c'
+    Airspeed Estimate:
+      topic: '/estimated_state/va'
 
 Course:
   node: '/autopilot'
@@ -60,8 +72,12 @@ Course:
       description: 'Course I gain'
   plot_axis_label: 'Course (deg)'
   plot_topics:
-    Course Command: '/controller_command/chi_c'
-    Course Estimate: '/estimated_state/chi'
+    Course Command:
+      topic: '/controller_command/chi_c'
+      scale: 57.2957795131
+    Course Estimate:
+      topic: '/estimated_state/chi'
+      scale: 57.2957795131
 
 Altitude:
   node: '/autopilot'
@@ -72,8 +88,11 @@ Altitude:
       description: 'Altitude I gain'
   plot_axis_label: 'Altitude (m)'
   plot_topics:
-    Altitude Command: '/controller_command/h_c'
-    Altitude Estimate: '/estimated_state/position[2]'
+    Altitude Command:
+      topic: '/controller_command/h_c'
+    Altitude Estimate:
+      topic: '/estimated_state/position[2]'
+      scale: -1.0
 
 Line Following:
   node: '/path_follower'

--- a/rosflight_rqt_plugins/resources/param_tuning_example_config.yaml
+++ b/rosflight_rqt_plugins/resources/param_tuning_example_config.yaml
@@ -8,12 +8,14 @@
 #       description: '{Parameter description}'
 #       scale: {Scale factor to use with parameters}  (optional, default is 1.0)
 #     ...
-#   plot_topics: (optional, include if you want to plot data)
+#   (Everything below this is optional if you don't want to plot data)
+#   plot_topics:
 #     {Plot name}:
 #       topic: '/{ROS_topic_name}/{field_name}'
 #       scale: {Scale factor to use with data}  (optional, default is 1.0)
 #     ...
 #   plot_axis_label: '{Y Axis Label}'  (x axis is always 'Time (s)')
+#   plot_axis_range: [min, max]  (optional, default is auto scaling)
 # ...
 
 
@@ -32,6 +34,7 @@ Roll Angle:
       topic: '/estimated_state/phi'
       scale: 57.2957795131
   plot_axis_label: 'Roll angle (deg)'
+  plot_axis_range: [-30, 30]
 
 Pitch Angle:
   node: '/autopilot'
@@ -48,6 +51,7 @@ Pitch Angle:
       topic: '/estimated_state/theta'
       scale: 57.2957795131
   plot_axis_label: 'Pitch angle (deg)'
+  plot_axis_range: [-30, 30]
 
 Airspeed:
   node: '/autopilot'
@@ -78,6 +82,7 @@ Course:
       topic: '/estimated_state/chi'
       scale: 57.2957795131
   plot_axis_label: 'Course (deg)'
+  plot_axis_range: [-180, 180]
 
 Altitude:
   node: '/autopilot'

--- a/rosflight_rqt_plugins/resources/param_tuning_example_config.yaml
+++ b/rosflight_rqt_plugins/resources/param_tuning_example_config.yaml
@@ -83,7 +83,7 @@ Altitude:
     y_label: 'Altitude (m)'
   plot_topics:
     Altitude Command: '/controller_command/h_c'
-#    Altitude Estimate: '/estimated_state/position[2]'
+    Altitude Estimate: '/estimated_state/position[2]'
 
 Line Following:
   node: '/path_follower'

--- a/rosflight_rqt_plugins/resources/param_tuning_example_config.yaml
+++ b/rosflight_rqt_plugins/resources/param_tuning_example_config.yaml
@@ -6,8 +6,16 @@
 #   params:
 #     {param_name}:
 #       description: '{Parameter Description}'
-#       scale: {Scale Factor to use in GUI} (optional, default is 1.0)
+#       scale: {Scale Factor to use with GUI}  (optional, default is 1.0)
 #     ...
+#   plot_axes:
+#     y_label: '{Y Axis Label}'  (x_axis is always 'Time (s)')
+#     y_scale: {Scale Factor to use with plot}  (optional, default is 1.0)
+#   plot_topics: (optional, include if you want to plot data)
+#     {Plot Name}: '/{ROS_topic_name}/{field_name}'
+#     ...
+# ...
+
 
 Roll Angle:
   node: '/autopilot'
@@ -16,6 +24,12 @@ Roll Angle:
       description: 'Roll Angle P Gain'
     r_kd:
       description: 'Roll Angle D Gain'
+  plot_axes:
+    y_label: 'Roll angle (deg)'
+    y_scale: 57.2957795131
+  plot_topics:
+    Roll Command: '/controller_internals/phi_c'
+    Roll Estimate: '/estimated_state/phi'
 
 Pitch Angle:
   node: '/autopilot'
@@ -24,6 +38,12 @@ Pitch Angle:
       description: 'Pitch Angle P Gain'
     p_kd:
       description:  'Pitch Angle D Gain'
+  plot_axes:
+    y_label: 'Pitch angle (deg)'
+    y_scale: 57.2957795131
+  plot_topics:
+    Pitch Command: '/controller_internals/theta_c'
+    Pitch Estimate: '/estimated_state/theta'
 
 Airspeed:
   node: '/autopilot'
@@ -32,6 +52,11 @@ Airspeed:
       description:  'Airspeed P Gain'
     a_t_ki:
       description:  'Airspeed I Gain'
+  plot_axes:
+    y_label: 'Airspeed (m/s)'
+  plot_topics:
+    Airspeed Command: '/controller_command/va_c'
+    Airspeed Estimate: '/estimated_state/va'
 
 Course:
   node: '/autopilot'
@@ -40,6 +65,12 @@ Course:
       description:  'Course P Gain'
     c_ki:
       description: 'Course I Gain'
+  plot_axes:
+    y_label: 'Course (deg)'
+    y_scale: 57.2957795131
+  plot_topics:
+    Course Command: '/controller_command/chi_c'
+    Course Estimate: '/estimated_state/chi'
 
 Altitude:
   node: '/autopilot'
@@ -48,6 +79,11 @@ Altitude:
       description:  'Altitude P Gain'
     a_ki:
       description: 'Altitude I Gain'
+  plot_axes:
+    y_label: 'Altitude (m)'
+  plot_topics:
+    Altitude Command: '/controller_command/h_c'
+    Altitude Estimate: '/estimated_state/h'
 
 Line Following:
   node: '/path_follower'

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
@@ -15,7 +15,7 @@ class ParamTuning(Plugin):
         self.setObjectName('ParamTuning')
 
         self._context = context
-        self._node = context.node  # TODO: Use this instead of making another node for the client
+        self._node = context.node
 
         # Load the configuration file
         args = self._parse_args(context.argv())
@@ -34,7 +34,7 @@ class ParamTuning(Plugin):
         self._paramFilepath = args.param_filepath
 
         # Initialize the ROS client
-        self._client = ParameterClient(self._config)
+        self._client = ParameterClient(self._config, self._node)
 
         # Initialize the widget
         self._widget = ParamTuningWidget(self._config, self._client, self._paramFilepath)

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
@@ -4,8 +4,9 @@ import yaml
 from rqt_gui_py.plugin import Plugin
 from python_qt_binding.QtWidgets import QFileDialog
 
-from .param_tuning_widget import ParamTuningWidget
 from .param_tuning_client import ParameterClient
+from .param_tuning_plotter import ParamTuningPlotter
+from .param_tuning_widget import ParamTuningWidget
 
 class ParamTuning(Plugin):
 
@@ -40,6 +41,10 @@ class ParamTuning(Plugin):
         if context.serial_number() > 1:
             self._widget.setWindowTitle(
                 self._widget.windowTitle() + (' (%d)' % context.serial_number()))
+
+        # Initialize the plotter
+        self._plotter = ParamTuningPlotter(self._config, self._client, self._widget.layout().itemAtPosition(0, 0))
+
         context.add_widget(self._widget)
 
     def _parse_args(self, argv):

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
@@ -2,7 +2,7 @@ import argparse
 import yaml
 
 from rqt_gui_py.plugin import Plugin
-from python_qt_binding.QtWidgets import QFileDialog
+from python_qt_binding.QtWidgets import QFileDialog, QVBoxLayout
 
 from .param_tuning_client import ParameterClient
 from .param_tuning_plotter import ParamTuningPlotter
@@ -43,7 +43,8 @@ class ParamTuning(Plugin):
                 self._widget.windowTitle() + (' (%d)' % context.serial_number()))
 
         # Initialize the plotter
-        self._plotter = ParamTuningPlotter(self._config, self._client, self._widget.layout().itemAtPosition(0, 0))
+        plotLayout = self._widget.findChild(QVBoxLayout, 'plotLayout')
+        self._plotter = ParamTuningPlotter(self._config, self._client, plotLayout)
 
         context.add_widget(self._widget)
 

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
@@ -36,7 +36,7 @@ class ParamTuning(Plugin):
         self._paramFilepath = args.param_filepath
 
         # Initialize the ROS client
-        self._client = ParameterClient(self._config, self._node, 15.0)
+        self._client = ParameterClient(self._config, self._node, 10)
 
         # Initialize the widget
         self._widget = ParamTuningWidget(self._config, self._client, self._paramFilepath)
@@ -65,5 +65,6 @@ class ParamTuning(Plugin):
 
     def shutdown_plugin(self):
         self._client.shutdown()
+        self._plotter.shutdown()
         self._node.destroy_node()
         rclpy.shutdown()

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
@@ -49,6 +49,7 @@ class ParamTuning(Plugin):
         self._plotter = ParamTuningPlotter(self._config, self._client, plot_layout)
         self._widget.register_plot_swap_callback(self._plotter.switch_plot_group)
         self._widget.register_duration_change_callback(self._client.set_data_hist_duration)
+        self._widget.register_pause_plot_callback(self._plotter.pause_plotting)
 
         context.add_widget(self._widget)
 

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
@@ -36,7 +36,7 @@ class ParamTuning(Plugin):
         self._paramFilepath = args.param_filepath
 
         # Initialize the ROS client
-        self._client = ParameterClient(self._config, self._node, 10)
+        self._client = ParameterClient(self._config, self._node, 20)
 
         # Initialize the widget
         self._widget = ParamTuningWidget(self._config, self._client, self._paramFilepath)

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
@@ -15,7 +15,7 @@ class ParamTuning(Plugin):
         self.setObjectName('ParamTuning')
 
         self._context = context
-        self._node = context.node
+        self._node = context.node  # TODO: Use this instead of making another node for the client
 
         # Load the configuration file
         args = self._parse_args(context.argv())

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
@@ -36,7 +36,7 @@ class ParamTuning(Plugin):
         self._param_filepath = args.param_filepath
 
         # Initialize the ROS client
-        self._client = ParameterClient(self._config, self._node, 20)
+        self._client = ParameterClient(self._config, self._node)
 
         # Initialize the widget
         self._widget = ParamTuningWidget(self._config, self._client, self._param_filepath)
@@ -47,7 +47,8 @@ class ParamTuning(Plugin):
         # Initialize the plotter
         plot_layout = self._widget.findChild(QVBoxLayout, 'plot_layout')
         self._plotter = ParamTuningPlotter(self._config, self._client, plot_layout)
-        self._widget.register_plot_swap_callback(self._plotter.switchPlotGroup)
+        self._widget.register_plot_swap_callback(self._plotter.switch_plot_group)
+        self._widget.register_duration_change_callback(self._client.set_data_hist_duration)
 
         context.add_widget(self._widget)
 

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
@@ -14,6 +14,7 @@ class ParamTuning(Plugin):
     def __init__(self, context):
         super(ParamTuning, self).__init__(context)
         self.setObjectName('ParamTuning')
+        x_axis_length = 5.0
 
         self._context = context
         self._node = context.node
@@ -35,10 +36,10 @@ class ParamTuning(Plugin):
         self._paramFilepath = args.param_filepath
 
         # Initialize the ROS client
-        self._client = ParameterClient(self._config, self._node)
+        self._client = ParameterClient(self._config, self._node, x_axis_length * 1.5)
 
         # Initialize the widget
-        self._widget = ParamTuningWidget(self._config, self._client, self._paramFilepath)
+        self._widget = ParamTuningWidget(self._config, self._client, self._paramFilepath, x_axis_length)
         if context.serial_number() > 1:
             self._widget.setWindowTitle(
                 self._widget.windowTitle() + (' (%d)' % context.serial_number()))

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
@@ -45,7 +45,7 @@ class ParamTuning(Plugin):
                 self._widget.windowTitle() + (' (%d)' % context.serial_number()))
 
         # Initialize the plotter
-        plotLayout = self._widget.findChild(QVBoxLayout, 'plotLayout')
+        plotLayout = self._widget.findChild(QVBoxLayout, 'plot_layout')
         self._plotter = ParamTuningPlotter(self._config, self._client, plotLayout)
         self._widget.registerPlotSwapCallback(self._plotter.switchPlotGroup)
 

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
@@ -1,6 +1,7 @@
 import argparse
 import yaml
 
+import rclpy
 from rqt_gui_py.plugin import Plugin
 from python_qt_binding.QtWidgets import QFileDialog, QVBoxLayout
 
@@ -61,3 +62,8 @@ class ParamTuning(Plugin):
         group.add_argument('--config-filepath', type=str, help='Path to the .yaml GUI configuration file')
         group.add_argument('--param-filepath', type=str, help='Path to the ROS .yaml parameter file, to save the'
                                                               ' parameters to')
+
+    def shutdown_plugin(self):
+        self._client.shutdown()
+        self._node.destroy_node()
+        rclpy.shutdown()

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
@@ -15,7 +15,6 @@ class ParamTuning(Plugin):
     def __init__(self, context):
         super(ParamTuning, self).__init__(context)
         self.setObjectName('ParamTuning')
-        x_axis_length = 5.0
 
         self._context = context
         self._node = context.node
@@ -37,10 +36,10 @@ class ParamTuning(Plugin):
         self._paramFilepath = args.param_filepath
 
         # Initialize the ROS client
-        self._client = ParameterClient(self._config, self._node, x_axis_length * 1.5)
+        self._client = ParameterClient(self._config, self._node, 15.0)
 
         # Initialize the widget
-        self._widget = ParamTuningWidget(self._config, self._client, self._paramFilepath, x_axis_length)
+        self._widget = ParamTuningWidget(self._config, self._client, self._paramFilepath)
         if context.serial_number() > 1:
             self._widget.setWindowTitle(
                 self._widget.windowTitle() + (' (%d)' % context.serial_number()))
@@ -48,6 +47,7 @@ class ParamTuning(Plugin):
         # Initialize the plotter
         plotLayout = self._widget.findChild(QVBoxLayout, 'plotLayout')
         self._plotter = ParamTuningPlotter(self._config, self._client, plotLayout)
+        self._widget.registerPlotSwapCallback(self._plotter.switchPlotGroup)
 
         context.add_widget(self._widget)
 

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
@@ -8,6 +8,7 @@ from .param_tuning_client import ParameterClient
 from .param_tuning_plotter import ParamTuningPlotter
 from .param_tuning_widget import ParamTuningWidget
 
+
 class ParamTuning(Plugin):
 
     def __init__(self, context):

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
@@ -33,21 +33,21 @@ class ParamTuning(Plugin):
             self._config = yaml.safe_load(file)
 
         # Get the filepath to save params to
-        self._paramFilepath = args.param_filepath
+        self._param_filepath = args.param_filepath
 
         # Initialize the ROS client
         self._client = ParameterClient(self._config, self._node, 20)
 
         # Initialize the widget
-        self._widget = ParamTuningWidget(self._config, self._client, self._paramFilepath)
+        self._widget = ParamTuningWidget(self._config, self._client, self._param_filepath)
         if context.serial_number() > 1:
             self._widget.setWindowTitle(
                 self._widget.windowTitle() + (' (%d)' % context.serial_number()))
 
         # Initialize the plotter
-        plotLayout = self._widget.findChild(QVBoxLayout, 'plot_layout')
-        self._plotter = ParamTuningPlotter(self._config, self._client, plotLayout)
-        self._widget.registerPlotSwapCallback(self._plotter.switchPlotGroup)
+        plot_layout = self._widget.findChild(QVBoxLayout, 'plot_layout')
+        self._plotter = ParamTuningPlotter(self._config, self._client, plot_layout)
+        self._widget.register_plot_swap_callback(self._plotter.switchPlotGroup)
 
         context.add_widget(self._widget)
 

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
@@ -49,7 +49,10 @@ class ParamTuning(Plugin):
         self._plotter = ParamTuningPlotter(self._config, self._client, plot_layout)
         self._widget.register_plot_swap_callback(self._plotter.switch_plot_group)
         self._widget.register_duration_change_callback(self._client.set_data_hist_duration)
-        self._widget.register_pause_plot_callback(self._plotter.pause_plotting)
+        def pause_plotting(pause: bool):
+            self._plotter.pause_plotting(pause)
+            self._client.pause_data_collection(pause)
+        self._widget.register_pause_plot_callback(pause_plotting)
 
         context.add_widget(self._widget)
 

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_client.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_client.py
@@ -13,6 +13,7 @@ class ParameterClient():
         self._config = config
         self._node = node
         self._hist_duration = 10.0
+        self._record_data = True
         # Threading lock, since get_data may be called by an external thread
         self._lock = threading.Lock()
 
@@ -75,6 +76,9 @@ class ParameterClient():
 
     def _message_callback(self, msg, topic_name: str) -> None:
         with self._lock:
+            if not self._record_data:
+                return
+
             msg_time = msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9
             curr_time = self._node.get_clock().now()
             curr_time = curr_time.seconds_nanoseconds()[0] + curr_time.seconds_nanoseconds()[1] * 1e-9
@@ -169,6 +173,9 @@ class ParameterClient():
 
     def set_data_hist_duration(self, duration: float) -> None:
         self._hist_duration = duration
+
+    def pause_data_collection(self, pause: bool) -> None:
+        self._record_data = not pause
 
     def print_info(self, message: str) -> None:
         self._node.get_logger().info(message)

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_client.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_client.py
@@ -85,6 +85,16 @@ class ParameterClient():
             while curr_time - self._data_history[topic_name][(field_name, field_index)][0][1] > self._hist_duration:
                 self._data_history[topic_name][(field_name, field_index)].pop(0)
 
+    def get_data(self, topic_str: str) -> tuple[list, list]:
+        topic_name, field_name, field_index = self._split_topic_str(topic_str)
+        x_data = []
+        y_data = []
+        for data in self._data_history[topic_name][(field_name, field_index)]:
+            x_data.append(data[1])
+            y_data.append(data[0])
+
+        return x_data, y_data
+
     def get_param(self, group: str, param: str, scaled: bool = True) -> float:
         if not scaled or 'scale' not in self._config[group]['params'][param]:
             scale = 1.0

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_client.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_client.py
@@ -14,7 +14,7 @@ class ParameterClient():
         self._node = node
         self._hist_duration = hist_duration
         # Minimum time between data points accepted, to reduce amount of data to plot
-        self._min_delta_time = hist_duration / 150
+        self._min_delta_time = hist_duration / 250
         # Threading lock, since get_data may be called by an external thread
         self._lock = threading.Lock()
 

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_client.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_client.py
@@ -156,3 +156,10 @@ class ParameterClient():
 
     def print_fatal(self, message: str) -> None:
         self._node.get_logger().fatal(message)
+
+    def shutdown(self) -> None:
+        for topic in self._plot_subscribers:
+            self._plot_subscribers[topic].destroy()
+        for client in self._set_clients:
+            self._set_clients[client].destroy()
+            self._get_clients[client].destroy()

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_client.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_client.py
@@ -14,6 +14,8 @@ class ParameterClient():
         self._node = node
         self._hist_duration = 10.0
         self._record_data = True
+        ros_time = node.get_clock().now()
+        self._initial_time = ros_time.seconds_nanoseconds()[0] + ros_time.seconds_nanoseconds()[1] * 1e-9
         # Threading lock, since get_data may be called by an external thread
         self._lock = threading.Lock()
 
@@ -79,9 +81,10 @@ class ParameterClient():
             if not self._record_data:
                 return
 
-            msg_time = msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9
+            msg_time = msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9 - self._initial_time
             curr_time = self._node.get_clock().now()
-            curr_time = curr_time.seconds_nanoseconds()[0] + curr_time.seconds_nanoseconds()[1] * 1e-9
+            curr_time = curr_time.seconds_nanoseconds()[0] + curr_time.seconds_nanoseconds()[1] * 1e-9 \
+                        - self._initial_time
 
             # Skip storing message if time since last message is less than minimum delta time
             first_array = next(iter(self._data_history[topic_name].values()))

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_client.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_client.py
@@ -37,8 +37,9 @@ class ParameterClient():
         self._data_history = {}
         for group in config:
             if 'plot_topics' in config[group]:
-                for topic in config[group]['plot_topics']:
-                    topic_name, field_name, field_index = self._split_topic_str(config[group]['plot_topics'][topic])
+                for plot_name in config[group]['plot_topics']:
+                    topic_name, field_name, field_index = \
+                        self._split_topic_str(config[group]['plot_topics'][plot_name]['topic'])
 
                     if topic_name not in self._plot_subscribers:
                         message_type = self._get_message_type(topic_name)
@@ -115,10 +116,10 @@ class ParameterClient():
             return x_data, y_data
 
     def get_param(self, group: str, param: str, scaled: bool = True) -> float:
-        if not scaled or 'scale' not in self._config[group]['params'][param]:
+        if not scaled:
             scale = 1.0
         else:
-            scale = self._config[group]['params'][param]['scale']
+            scale = self._config[group]['params'][param].get('scale', 1.0)
         node_name = self._config[group]['node']
 
         request = GetParameters.Request()
@@ -153,8 +154,8 @@ class ParameterClient():
         thread.start()
 
     def _set_param(self, group: str, param: str, value: float, scaled: bool = True) -> None:
-        if scaled and 'scale' in self._config[group]['params'][param]:
-            value /= self._config[group]['params'][param]['scale']
+        if scaled:
+            value /= self._config[group]['params'][param].get('scale', 1.0)
 
         node_name = self._config[group]['node']
         request = SetParameters.Request()

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_client.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_client.py
@@ -14,7 +14,7 @@ class ParameterClient():
         self._node = node
         self._hist_duration = hist_duration
         # Minimum time between data points accepted, to reduce amount of data to plot
-        self._min_delta_time = hist_duration / 200
+        self._min_delta_time = hist_duration / 150
         # Threading lock, since get_data may be called by an external thread
         self._lock = threading.Lock()
 

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_client.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_client.py
@@ -8,91 +8,94 @@ from rosidl_runtime_py.utilities import get_message
 
 class ParameterClient():
     def __init__(self, config: dict, node: Node, hist_duration: float):
-        self.config = config
-        self.node = node
-        self.hist_duration = hist_duration
+        self._config = config
+        self._node = node
+        self._hist_duration = hist_duration
 
         # Initialize parameter clients
-        self.set_clients = {}
-        self.get_clients = {}
+        self._set_clients = {}
+        self._get_clients = {}
         for group in config:
             node_name = config[group]['node']
-            if node_name not in self.set_clients:
-                self.set_clients[node_name] = self.node.create_client(SetParameters, f'{node_name}/set_parameters')
-                while not self.set_clients[node_name].wait_for_service(timeout_sec=1.0):
-                    self.node.get_logger().info(f'{node_name}/set_parameters service not available, waiting...')
-                self.get_clients[node_name] = self.node.create_client(GetParameters, f'{node_name}/get_parameters')
-                while not self.get_clients[node_name].wait_for_service(timeout_sec=1.0):
-                    self.node.get_logger().info(f'{node_name}/get_parameters service not available, waiting...')
+            if node_name not in self._set_clients:
+                self._set_clients[node_name] = self._node.create_client(SetParameters, f'{node_name}/set_parameters')
+                while not self._set_clients[node_name].wait_for_service(timeout_sec=1.0):
+                    self._node.get_logger().info(f'{node_name}/set_parameters service not available, waiting...')
+                self._get_clients[node_name] = self._node.create_client(GetParameters, f'{node_name}/get_parameters')
+                while not self._get_clients[node_name].wait_for_service(timeout_sec=1.0):
+                    self._node.get_logger().info(f'{node_name}/get_parameters service not available, waiting...')
 
         # Initialize topics subscribers for plotting
-        self.plot_subscribers = {}
-        self.data_history = {}
+        self._plot_subscribers = {}
+        self._data_history = {}
         for group in config:
             if 'plot_topics' in config[group]:
                 for topic in config[group]['plot_topics']:
-                    # Get the topic name, field name, and optional index
-                    topic_name = config[group]['plot_topics'][topic].split('/')[1]
-                    field = config[group]['plot_topics'][topic].split('/')[2]
-                    match = re.match(r"(\w+)\[(\d+)\]", field)
-                    if match:
-                        field_name = match.group(1)
-                        field_index = int(match.group(2))
-                    else: # No index
-                        field_name = field
-                        field_index = None
+                    topic_name, field_name, field_index = self._split_topic_str(config[group]['plot_topics'][topic])
 
-                    # Create the subscribers
-                    if topic_name not in self.plot_subscribers:
-                        message_type = self.get_message_type(topic_name)
+                    if topic_name not in self._plot_subscribers:
+                        message_type = self._get_message_type(topic_name)
                         if message_type is None:
-                            self.node.get_logger().error(f'Failed to get message type for {topic_name},'
+                            self._node.get_logger().error(f'Failed to get message type for {topic_name},'
                                                          f' does the topic exist?')
                         else:
-                            self.plot_subscribers[topic_name] = self.node.create_subscription(
+                            self._plot_subscribers[topic_name] = self._node.create_subscription(
                                 message_type,
                                 topic_name,
-                                lambda msg, t=topic_name: self.message_callback(msg, t),
+                                lambda msg, t=topic_name: self._message_callback(msg, t),
                                 10
                             )
-                            self.data_history[topic_name] = {(field_name, field_index): []}
+                            self._data_history[topic_name] = {(field_name, field_index): []}
                     else:
-                        self.data_history[topic_name][(field_name, field_index)] = []
+                        self._data_history[topic_name][(field_name, field_index)] = []
 
-    def get_message_type(self, topic_name: str):
-        topic_array = self.node.get_topic_names_and_types()
+    def _split_topic_str(self, topic_str: str) -> tuple:
+        topic_name = topic_str.split('/')[1]
+        field = topic_str.split('/')[2]
+        match = re.match(r"(\w+)\[(\d+)\]", field)
+        if match:
+            field_name = match.group(1)
+            field_index = int(match.group(2))
+        else:
+            field_name = field
+            field_index = None
+
+        return topic_name, field_name, field_index
+
+    def _get_message_type(self, topic_name: str):
+        topic_array = self._node.get_topic_names_and_types()
         for topic in topic_array:
             if topic[0] == '/' + topic_name:
                 return get_message(topic[1][0])
         return None
 
-    def message_callback(self, msg, topic_name: str):
-        for field in self.data_history[topic_name]:
+    def _message_callback(self, msg, topic_name: str) -> None:
+        for field in self._data_history[topic_name]:
             field_name = field[0]
             field_index = field[1]
 
             # Add new values to array
             msg_value = getattr(msg, field_name) if field_index is None else getattr(msg, field_name)[field_index]
             msg_time = msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9
-            self.data_history[topic_name][(field_name, field_index)].append((msg_value, msg_time))
+            self._data_history[topic_name][(field_name, field_index)].append((msg_value, msg_time))
 
             # Remove old values
-            curr_time = self.node.get_clock().now()
+            curr_time = self._node.get_clock().now()
             curr_time = curr_time.to_msg().sec + curr_time.to_msg().nanosec * 1e-9
-            while curr_time - self.data_history[topic_name][(field_name, field_index)][0][1] > self.hist_duration:
-                self.data_history[topic_name][(field_name, field_index)].pop(0)
+            while curr_time - self._data_history[topic_name][(field_name, field_index)][0][1] > self._hist_duration:
+                self._data_history[topic_name][(field_name, field_index)].pop(0)
 
     def get_param(self, group: str, param: str, scaled: bool = True) -> float:
-        if not scaled or 'scale' not in self.config[group]['params'][param]:
+        if not scaled or 'scale' not in self._config[group]['params'][param]:
             scale = 1.0
         else:
-            scale = self.config[group]['params'][param]['scale']
-        node_name = self.config[group]['node']
+            scale = self._config[group]['params'][param]['scale']
+        node_name = self._config[group]['node']
 
         request = GetParameters.Request()
         request.names = [param]
 
-        future = self.get_clients[node_name].call_async(request)
+        future = self._get_clients[node_name].call_async(request)
 
         call_time = time.time()
         callback_complete = False
@@ -101,29 +104,29 @@ class ParameterClient():
                 callback_complete = True
                 break
         if not callback_complete or future.result() is None:
-            self.node.get_logger().error(f'Failed to get {node_name}/{param} after 5 seconds')
+            self._node.get_logger().error(f'Failed to get {node_name}/{param} after 5 seconds')
             return 0.0
 
         if future.result() is not None:
             if len(future.result().values) == 0:
-                self.node.get_logger().error(f'Parameter {param} not found')
+                self._node.get_logger().error(f'Parameter {param} not found')
                 return 0.0
             if future.result().values[0].type == ParameterType.PARAMETER_DOUBLE:
                 return future.result().values[0].double_value * scale
             else:
-                self.node.get_logger().error(f'Unsupported parameter type for {param}, only double is supported')
+                self._node.get_logger().error(f'Unsupported parameter type for {param}, only double is supported')
         else:
-            self.node.get_logger().error('Service call failed %r' % (future.exception(),))
+            self._node.get_logger().error('Service call failed %r' % (future.exception(),))
 
     def set_param(self, group: str, param: str, value: float, scaled: bool = True) -> None:
-        if scaled and 'scale' in self.config[group]['params'][param]:
-            value /= self.config[group]['params'][param]['scale']
+        if scaled and 'scale' in self._config[group]['params'][param]:
+            value /= self._config[group]['params'][param]['scale']
 
-        node_name = self.config[group]['node']
+        node_name = self._config[group]['node']
         request = SetParameters.Request()
         parameter = Parameter(param, Parameter.Type.DOUBLE, value)
         request.parameters.append(parameter.to_parameter_msg())
-        future = self.set_clients[node_name].call_async(request)
+        future = self._set_clients[node_name].call_async(request)
 
         call_time = time.time()
         callback_complete = False
@@ -132,24 +135,24 @@ class ParameterClient():
                 callback_complete = True
                 break
         if not callback_complete or future.result() is None:
-            self.node.get_logger().error(f'Failed to set {node_name}/{param} after 5 seconds')
+            self._node.get_logger().error(f'Failed to set {node_name}/{param} after 5 seconds')
 
         if future.result() is not None:
             if future.result().results[0].successful:
-                self.node.get_logger().info(f'Set {node_name}/{param} to {value}')
+                self._node.get_logger().info(f'Set {node_name}/{param} to {value}')
             else:
-                self.node.get_logger().error(f'Failed to set {param} to {value}: {future.result().results[0].reason}')
+                self._node.get_logger().error(f'Failed to set {param} to {value}: {future.result().results[0].reason}')
         else:
-            self.node.get_logger().error('Service call failed %r' % (future.exception(),))
+            self._node.get_logger().error('Service call failed %r' % (future.exception(),))
 
-    def print_info(self, message: str):
-        self.node.get_logger().info(message)
+    def print_info(self, message: str) -> None:
+        self._node.get_logger().info(message)
 
-    def print_warning(self, message: str):
-        self.node.get_logger().warning(message)
+    def print_warning(self, message: str) -> None:
+        self._node.get_logger().warning(message)
 
-    def print_error(self, message: str):
-        self.node.get_logger().error(message)
+    def print_error(self, message: str) -> None:
+        self._node.get_logger().error(message)
 
-    def print_fatal(self, message: str):
-        self.node.get_logger().fatal(message)
+    def print_fatal(self, message: str) -> None:
+        self._node.get_logger().fatal(message)

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
@@ -51,6 +51,7 @@ class ParamTuningPlotter(QWidget):
                 self._ax.tick_params(axis='both', labelsize=self._fontSize)
                 self._ax.grid(True)
                 self._lineObjects = {}
+                self._canvas.figure.subplots_adjust(left=0.05, right=0.95, top=0.95, bottom=0.05)
 
             for topic in self._config[self._currentGroup]['plot_topics']:
                 topic_str = self._config[self._currentGroup]['plot_topics'][topic]

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
@@ -3,11 +3,12 @@ import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
 
+from python_qt_binding.QtCore import QTimer
 from python_qt_binding.QtGui import QFont
 from python_qt_binding.QtWidgets import QWidget, QVBoxLayout, QApplication
 
 class ParamTuningPlotter(QWidget):
-    def __init__(self, config: dict, paramClient, layout: QVBoxLayout):
+    def __init__(self, config: dict, paramClient, layout: QVBoxLayout, plotRate: float=5):
         super(ParamTuningPlotter, self).__init__()
         self.setObjectName('ParamTuningPlotter')
 
@@ -23,21 +24,34 @@ class ParamTuningPlotter(QWidget):
         elif default_font.pixelSize() > 0:
             self._fontSize = default_font.pixelSize() * 2
 
-        self._plot()
+        self._timer = QTimer(self)
+        self._timer.timeout.connect(self._plot)
+        self._timer.start(int(1000 / plotRate))
+
+        # Plot parameters
+        self._currentGroup = list(self._config.keys())[0]
 
     def _plot(self):
+        self._canvas.figure.clear()
         self._ax = self._canvas.figure.subplots()
         self._ax.set_xlabel('Time (s)', fontsize=self._fontSize)
         self._ax.set_ylabel('Value', fontsize=self._fontSize)
         self._ax.tick_params(axis='both', labelsize=self._fontSize)
         self._ax.grid(True)
-        x = np.linspace(0, 10, 100)
-        y1 = np.sin(x)
-        y2 = np.cos(x)
-        self._ax.plot(x, y1, label='sin(x)')
-        self._ax.plot(x, y2, label='cos(x)')
+
+        plot_topics = self._config[self._currentGroup]['plot_topics']
+        for topic in plot_topics:
+            topic_str = self._config[self._currentGroup]['plot_topics'][topic]
+            x, y = self._paramClient.get_data(topic_str)
+            self._ax.plot(x, y, label=topic)
+
         self._ax.legend(loc='upper right', fontsize=self._fontSize)
         self._canvas.draw()
 
     def switchPlotGroup(self, group: str) -> None:
-        print(f'Switching plot to {group}')
+        self._currentGroup = group
+        self._plot()
+
+    def shutdown(self):
+        self._timer.stop()
+        self._canvas.close()

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
@@ -77,6 +77,12 @@ class ParamTuningPlotter(QWidget):
             self._plot_initialized = False
             self._update_plot()
 
+    def pause_plotting(self, pause: bool) -> None:
+        if pause:
+            self._timer.stop()
+        else:
+            self._timer.start()
+
     def shutdown(self):
         self._timer.stop()
         self._canvas.close()

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
@@ -47,7 +47,7 @@ class ParamTuningPlotter(QWidget):
                 self._canvas.figure.clear()
                 self._ax = self._canvas.figure.subplots()
                 self._ax.set_xlabel('Time (s)', fontsize=self._font_size)
-                self._ax.set_ylabel(self._config[self._current_group]['plot_axes']['y_label'], fontsize=self._font_size)
+                self._ax.set_ylabel(self._config[self._current_group]['plot_axis_label'], fontsize=self._font_size)
                 self._ax.tick_params(axis='both', labelsize=self._font_size)
                 self._ax.grid(True)
                 self._lineObjects = {}

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
@@ -71,7 +71,7 @@ class ParamTuningPlotter(QWidget):
             self._canvas.draw()
             self._plot_initialized = True
 
-    def switchPlotGroup(self, group: str) -> None:
+    def switch_plot_group(self, group: str) -> None:
         with self._lock:
             self._current_group = group
             self._plot_initialized = False

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
@@ -44,6 +44,11 @@ class ParamTuningPlotter(QWidget):
 
     def _plot(self):
         with self._lock:
+            if 'plot_topics' not in self._config[self._current_group]:
+                self._canvas.figure.clear()
+                self._canvas.draw()
+                return
+
             if not self._plot_initialized:
                 self._canvas.figure.clear()
                 self._ax = self._canvas.figure.subplots()

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
@@ -59,6 +59,10 @@ class ParamTuningPlotter(QWidget):
                 self._lineObjects = {}
                 self._canvas.figure.subplots_adjust(left=0.05, right=0.98, top=0.98, bottom=0.05)
 
+                if 'plot_axis_range' in self._config[self._current_group]:
+                    min_value, max_value = self._config[self._current_group]['plot_axis_range']
+                    self._ax.set_ylim(min_value, max_value)
+
             for plot_name in self._config[self._current_group]['plot_topics']:
                 topic_str = self._config[self._current_group]['plot_topics'][plot_name]['topic']
                 x, y = self._param_client.get_data(topic_str)

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
@@ -1,4 +1,5 @@
 import threading
+import numpy as np
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
 
@@ -53,15 +54,16 @@ class ParamTuningPlotter(QWidget):
                 self._lineObjects = {}
                 self._canvas.figure.subplots_adjust(left=0.05, right=0.98, top=0.98, bottom=0.05)
 
-            for topic in self._config[self._current_group]['plot_topics']:
-                topic_str = self._config[self._current_group]['plot_topics'][topic]
+            for plot_name in self._config[self._current_group]['plot_topics']:
+                topic_str = self._config[self._current_group]['plot_topics'][plot_name]['topic']
                 x, y = self._param_client.get_data(topic_str)
+                y = np.array(y) * self._config[self._current_group]['plot_topics'][plot_name].get('scale', 1.0)
 
-                if topic not in self._lineObjects:
-                    line, = self._ax.plot(x, y, label=topic)
-                    self._lineObjects[topic] = line
+                if plot_name not in self._lineObjects:
+                    line, = self._ax.plot(x, y, label=plot_name)
+                    self._lineObjects[plot_name] = line
                 else:
-                    self._lineObjects[topic].set_data(x, y)
+                    self._lineObjects[plot_name].set_data(x, y)
 
             if not self._plot_initialized:
                 self._ax.legend(loc='upper right', fontsize=self._font_size)

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
@@ -51,7 +51,7 @@ class ParamTuningPlotter(QWidget):
                 self._ax.tick_params(axis='both', labelsize=self._font_size)
                 self._ax.grid(True)
                 self._lineObjects = {}
-                self._canvas.figure.subplots_adjust(left=0.05, right=0.95, top=0.95, bottom=0.05)
+                self._canvas.figure.subplots_adjust(left=0.05, right=0.98, top=0.98, bottom=0.05)
 
             for topic in self._config[self._current_group]['plot_topics']:
                 topic_str = self._config[self._current_group]['plot_topics'][topic]

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
@@ -11,30 +11,30 @@ class ParamTuningPlotter(QWidget):
         super(ParamTuningPlotter, self).__init__()
         self.setObjectName('ParamTuningPlotter')
 
-        self.config = config
-        self.paramClient = paramClient
-        self.canvas = FigureCanvasQTAgg(Figure())
-        layout.addWidget(self.canvas)
+        self._config = config
+        self._paramClient = paramClient
+        self._canvas = FigureCanvasQTAgg(Figure())
+        layout.addWidget(self._canvas)
 
         # Get current font size (not sure if this is needed on non-HiDPI screens?)
         default_font: QFont = QApplication.font()
         if default_font.pointSize() > 0:
-            self.fontSize = default_font.pointSize() * 2
+            self._fontSize = default_font.pointSize() * 2
         elif default_font.pixelSize() > 0:
-            self.fontSize = default_font.pixelSize() * 2
+            self._fontSize = default_font.pixelSize() * 2
 
-        self.plot()
+        self._plot()
 
-    def plot(self):
-        self.ax = self.canvas.figure.subplots()
-        self.ax.set_xlabel('Time (s)', fontsize=self.fontSize)
-        self.ax.set_ylabel('Value', fontsize=self.fontSize)
-        self.ax.tick_params(axis='both', labelsize=self.fontSize)
-        self.ax.grid(True)
+    def _plot(self):
+        self._ax = self._canvas.figure.subplots()
+        self._ax.set_xlabel('Time (s)', fontsize=self._fontSize)
+        self._ax.set_ylabel('Value', fontsize=self._fontSize)
+        self._ax.tick_params(axis='both', labelsize=self._fontSize)
+        self._ax.grid(True)
         x = np.linspace(0, 10, 100)
         y1 = np.sin(x)
         y2 = np.cos(x)
-        self.ax.plot(x, y1, label='sin(x)')
-        self.ax.plot(x, y2, label='cos(x)')
-        self.ax.legend(loc='upper right', fontsize=self.fontSize)
-        self.canvas.draw()
+        self._ax.plot(x, y1, label='sin(x)')
+        self._ax.plot(x, y2, label='cos(x)')
+        self._ax.legend(loc='upper right', fontsize=self._fontSize)
+        self._canvas.draw()

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
@@ -1,0 +1,25 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
+from matplotlib.figure import Figure
+
+from python_qt_binding.QtWidgets import QWidget, QVBoxLayout
+
+class ParamTuningPlotter(QWidget):
+    def __init__(self, config: dict, paramClient, layout: QVBoxLayout):
+        super(ParamTuningPlotter, self).__init__()
+        self.setObjectName('ParamTuningPlotter')
+
+        self.config = config
+        self.paramClient = paramClient
+        self.canvas = FigureCanvasQTAgg(Figure())
+        layout.addWidget(self.canvas)
+
+        self.ax = self.canvas.figure.subplots()
+        self.ax.set_xlabel('Time (s)')
+        self.ax.set_ylabel('Value')
+        self.ax.grid(True)
+        x = np.linspace(0, 10, 100)
+        y = np.sin(x)
+        self.ax.plot(x, y)
+        self.canvas.draw()

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
@@ -38,3 +38,6 @@ class ParamTuningPlotter(QWidget):
         self._ax.plot(x, y2, label='cos(x)')
         self._ax.legend(loc='upper right', fontsize=self._fontSize)
         self._canvas.draw()
+
+    def switchPlotGroup(self, group: str) -> None:
+        print(f'Switching plot to {group}')

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_plotter.py
@@ -3,7 +3,8 @@ import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
 
-from python_qt_binding.QtWidgets import QWidget, QVBoxLayout
+from python_qt_binding.QtGui import QFont
+from python_qt_binding.QtWidgets import QWidget, QVBoxLayout, QApplication
 
 class ParamTuningPlotter(QWidget):
     def __init__(self, config: dict, paramClient, layout: QVBoxLayout):
@@ -15,11 +16,25 @@ class ParamTuningPlotter(QWidget):
         self.canvas = FigureCanvasQTAgg(Figure())
         layout.addWidget(self.canvas)
 
+        # Get current font size (not sure if this is needed on non-HiDPI screens?)
+        default_font: QFont = QApplication.font()
+        if default_font.pointSize() > 0:
+            self.fontSize = default_font.pointSize() * 2
+        elif default_font.pixelSize() > 0:
+            self.fontSize = default_font.pixelSize() * 2
+
+        self.plot()
+
+    def plot(self):
         self.ax = self.canvas.figure.subplots()
-        self.ax.set_xlabel('Time (s)')
-        self.ax.set_ylabel('Value')
+        self.ax.set_xlabel('Time (s)', fontsize=self.fontSize)
+        self.ax.set_ylabel('Value', fontsize=self.fontSize)
+        self.ax.tick_params(axis='both', labelsize=self.fontSize)
         self.ax.grid(True)
         x = np.linspace(0, 10, 100)
-        y = np.sin(x)
-        self.ax.plot(x, y)
+        y1 = np.sin(x)
+        y2 = np.cos(x)
+        self.ax.plot(x, y1, label='sin(x)')
+        self.ax.plot(x, y2, label='cos(x)')
+        self.ax.legend(loc='upper right', fontsize=self.fontSize)
         self.canvas.draw()

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_widget.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_widget.py
@@ -9,52 +9,52 @@ from python_qt_binding.QtWidgets import QWidget, QPushButton, QFileDialog
 
 
 class ParamTuningWidget(QWidget):
-    def __init__(self, config: dict, paramClient, paramFilepath: str):
+    def __init__(self, config: dict, paramClient, param_filepath: str):
         # Initialize widget
         super(ParamTuningWidget, self).__init__()
         self.setObjectName('ParamTuningWidget')
-        self._paramFilePath = paramFilepath
-        self._addChangedValuesToHist = True
-        self._plotSwapCallback = lambda x: None
+        self._param_file_path = param_filepath
+        self._add_changed_values_to_hist = True
+        self._plot_swap_callback = lambda x: None
 
         # Load the UI file
         _, path = get_resource('packages', 'rosflight_rqt_plugins')
-        uiFile = os.path.join(path, 'share', 'rosflight_rqt_plugins', 'resources', 'param_tuning.ui')
-        loadUi(uiFile, self)
+        ui_file = os.path.join(path, 'share', 'rosflight_rqt_plugins', 'resources', 'param_tuning.ui')
+        loadUi(ui_file, self)
 
         # Define table formatting
         self._config = config
-        self._tableHeaders = ['Parameter', 'Value', 'Description', 'Reset to Previous', 'Reset to Initial']
-        self._tableWidths = [175, 125, 500, 250, 250]
+        self._table_headers = ['Parameter', 'Value', 'Description', 'Reset to Previous', 'Reset to Initial']
+        self._table_widths = [175, 125, 500, 250, 250]
 
         # Get the original values of the parameters
-        self._paramClient = paramClient
-        self._valueStack = {}
+        self._param_client = paramClient
+        self._value_stack = {}
         for group in config:
             for param in config[group]['params']:
-                value = self._paramClient.get_param(group, param)
-                self._valueStack[(group, param)] = [value]
+                value = self._param_client.get_param(group, param)
+                self._value_stack[(group, param)] = [value]
 
         # Set up the widget
         # Group selection - QComboBox
         self.group_selection.addItems(self._config.keys())
-        self.group_selection.currentTextChanged.connect(self._groupSelectionCallback)
+        self.group_selection.currentTextChanged.connect(self._group_selection_callback)
         # Refresh button - QPushButton
-        self.refresh_button.clicked.connect(self._refreshButtonCallback)
+        self.refresh_button.clicked.connect(self._refresh_button_callback)
         # Save to file button - QPushButton
-        self.save_button.clicked.connect(self._saveButtonCallback)
+        self.save_button.clicked.connect(self._save_button_callback)
         # Parameter table - QTableView
         self._setupTableModels()
-        self._createTableButtons()
-        self._refreshTableValues()
+        self._create_table_buttons()
+        self._refresh_table_values()
 
     def _setupTableModels(self):
         # Create a model for every group
         self._models = {}
-        self._currentGroupKey = list(self._config.keys())[0]
+        self._current_group_key = list(self._config.keys())[0]
         for group in self._config:
             model = QStandardItemModel()
-            model.setHorizontalHeaderLabels(self._tableHeaders)
+            model.setHorizontalHeaderLabels(self._table_headers)
             for param in self._config[group]['params']:
                 desc = self._config[group]['params'][param]['description']
                 param_item = QStandardItem(param)
@@ -66,111 +66,111 @@ class ParamTuningWidget(QWidget):
             self._models[group] = model
 
         # Load the first model into the table
-        self.param_table_view.setModel(self._models[self._currentGroupKey])
+        self.param_table_view.setModel(self._models[self._current_group_key])
 
         # Set the column widths
-        for i, width in enumerate(self._tableWidths):
+        for i, width in enumerate(self._table_widths):
             self.param_table_view.setColumnWidth(i, width)
 
         # Hide the number row
         self.param_table_view.verticalHeader().hide()
 
         # Connect the model change signal
-        self.param_table_view.model().dataChanged.connect(self._onModelChange)
+        self.param_table_view.model().dataChanged.connect(self._on_model_change)
 
-    def _createTableButtons(self):
+    def _create_table_buttons(self):
         # Get a list of gains for the current group
-        currentGroup = self._config[self._currentGroupKey]
-        currentParams = list(currentGroup['params'].keys())
+        current_group = self._config[self._current_group_key]
+        current_params = list(current_group['params'].keys())
 
-        for i, param in enumerate(currentParams):
+        for i, param in enumerate(current_params):
             # Create reset to previous buttons
-            previousButtonValue = self._valueStack[(self._currentGroupKey, param)][-2] \
-                if len(self._valueStack[(self._currentGroupKey, param)]) > 1 \
-                else self._valueStack[(self._currentGroupKey, param)][0]
+            previous_button_value = self._value_stack[(self._current_group_key, param)][-2] \
+                if len(self._value_stack[(self._current_group_key, param)]) > 1 \
+                else self._value_stack[(self._current_group_key, param)][0]
 
-            button = QPushButton(str(previousButtonValue))
+            button = QPushButton(str(previous_button_value))
             button.clicked.connect(
-                lambda _, g=self._currentGroupKey, index=i, p=param: self._resetPreviousButtonCallback(g, index, p)
+                lambda _, g=self._current_group_key, index=i, p=param: self._reset_previous_button_callback(g, index, p)
             )
             index = self.param_table_view.model().index(i, 3)
             self.param_table_view.setIndexWidget(index, button)
 
             # Create reset to original buttons
-            button = QPushButton(str(self._valueStack[(self._currentGroupKey, param)][0]))
+            button = QPushButton(str(self._value_stack[(self._current_group_key, param)][0]))
             button.clicked.connect(
-                lambda _, g=self._currentGroupKey, index=i, p=param: self._resetInitialButtonCallback(g, index, p)
+                lambda _, g=self._current_group_key, index=i, p=param: self._reset_initial_button_callback(g, index, p)
             )
             index = self.param_table_view.model().index(i, 4)
             self.param_table_view.setIndexWidget(index, button)
 
-    def _resetPreviousButtonCallback(self, group, row, param):
+    def _reset_previous_button_callback(self, group, row, param):
         # Pop the last value from list, unless it is the last value
-        if len(self._valueStack[(group, param)]) > 1:
-            self._valueStack[(group, param)].pop()
-        value = self._valueStack[(group, param)][-1]
+        if len(self._value_stack[(group, param)]) > 1:
+            self._value_stack[(group, param)].pop()
+        value = self._value_stack[(group, param)][-1]
 
         # Update the table
-        self._addChangedValuesToHist = False
+        self._add_changed_values_to_hist = False
         self._models[group].item(row, 1).setText(str(value))
-        self._addChangedValuesToHist = True
+        self._add_changed_values_to_hist = True
 
-    def _resetInitialButtonCallback(self, group, row, param):
-        self._models[group].item(row, 1).setText(str(self._valueStack[(group, param)][0]))
-        self._valueStack[(group, param)] = [self._valueStack[(group, param)][0]]
-        self._createTableButtons()
+    def _reset_initial_button_callback(self, group, row, param):
+        self._models[group].item(row, 1).setText(str(self._value_stack[(group, param)][0]))
+        self._value_stack[(group, param)] = [self._value_stack[(group, param)][0]]
+        self._create_table_buttons()
 
-    def _refreshTableValues(self):
-        self._paramClient.print_info('Getting all parameters from ROS network...')
+    def _refresh_table_values(self):
+        self._param_client.print_info('Getting all parameters from ROS network...')
 
         # Temporarily disconnect the model change signal
-        self.param_table_view.model().dataChanged.disconnect(self._onModelChange)
+        self.param_table_view.model().dataChanged.disconnect(self._on_model_change)
 
         # Get current values of the parameters
         for group in self._config:
             for i in range(self._models[group].rowCount()):
                 param = self._models[group].item(i, 0).text()
-                value = self._paramClient.get_param(group, param)
+                value = self._param_client.get_param(group, param)
 
                 # If the value is different from the previous value, add it to the stack and update the buttons
-                if value != self._valueStack[(group, param)][-1]:
-                    self._valueStack[(group, param)].append(value)
-                    self._createTableButtons()
+                if value != self._value_stack[(group, param)][-1]:
+                    self._value_stack[(group, param)].append(value)
+                    self._create_table_buttons()
 
                 # Update the table
                 self._models[group].item(i, 1).setText(str(value))
 
         # Reconnect the model change signal
-        self.param_table_view.model().dataChanged.connect(self._onModelChange)
+        self.param_table_view.model().dataChanged.connect(self._on_model_change)
 
-    def _groupSelectionCallback(self, text):
-        self._currentGroupKey = text
+    def _group_selection_callback(self, text):
+        self._current_group_key = text
 
         # Swap models and connect the model change signal to the new model
-        self.param_table_view.model().dataChanged.disconnect(self._onModelChange)
+        self.param_table_view.model().dataChanged.disconnect(self._on_model_change)
         self.param_table_view.setModel(self._models[text])
-        self.param_table_view.model().dataChanged.connect(self._onModelChange)
+        self.param_table_view.model().dataChanged.connect(self._on_model_change)
 
         # Update table
-        self._createTableButtons()
+        self._create_table_buttons()
 
         # Tell the plotter to swap the plot
-        self._plotSwapCallback(text)
+        self._plot_swap_callback(text)
 
-    def _refreshButtonCallback(self):
-        self._refreshTableValues()
+    def _refresh_button_callback(self):
+        self._refresh_table_values()
 
-    def _saveButtonCallback(self):
+    def _save_button_callback(self):
         # Request a filepath is a param filepath hasn't already been given
-        if self._paramFilePath is None:
+        if self._param_file_path is None:
             options = QFileDialog.Options()
             filepath, _ = QFileDialog.getSaveFileName(None, 'Save Parameters to ROS .yaml', '', 'YAML Files (*.yaml)',
                                                       options=options)
             if not filepath:
-                self._paramClient.print_warning('No file selected, parameters not saved.')
+                self._param_client.print_warning('No file selected, parameters not saved.')
                 return
         else:
-            filepath = self._paramFilePath
+            filepath = self._param_file_path
 
         # Load the existing parameter file if it exists
         if os.path.exists(filepath):
@@ -184,7 +184,7 @@ class ParamTuningWidget(QWidget):
             param_dict = {}
             for i in range(self._models[group].rowCount()):
                 param_name = self._models[group].item(i, 0).text()
-                param_dict[param_name] = self._paramClient.get_param(group, param_name, False)
+                param_dict[param_name] = self._param_client.get_param(group, param_name, False)
 
             # Add new items to dictionary, appending it if already exists
             stripped_node_name = self._config[group]['node'].lstrip('/')
@@ -198,32 +198,32 @@ class ParamTuningWidget(QWidget):
             yaml.dump(params, file)
 
     @pyqtSlot(QModelIndex, QModelIndex)
-    def _onModelChange(self, topLeft, bottomRight):
+    def _on_model_change(self, top_left, bottom_right):
         # Check if the value is a number
         try:
-            value = float(topLeft.data())
+            value = float(top_left.data())
         except ValueError:
-            self._paramClient.print_warning('Invalid value type, please enter a number.')
+            self._param_client.print_warning('Invalid value type, please enter a number.')
 
             # Restore the previous value
-            self.param_table_view.model().dataChanged.disconnect(self._onModelChange)
-            self.param_table_view.model().itemFromIndex(topLeft).setText(str(
-                self._valueStack[(self._currentGroupKey,
-                                  self._models[self._currentGroupKey].item(topLeft.row(), 0).text())][-1]))
-            self.param_table_view.model().dataChanged.connect(self._onModelChange)
+            self.param_table_view.model().dataChanged.disconnect(self._on_model_change)
+            self.param_table_view.model().itemFromIndex(top_left).setText(str(
+                self._value_stack[(self._current_group_key,
+                                   self._models[self._current_group_key].item(top_left.row(), 0).text())][-1]))
+            self.param_table_view.model().dataChanged.connect(self._on_model_change)
             return
 
         # Set the new value
-        param = self._models[self._currentGroupKey].item(topLeft.row(), 0).text()
-        self._paramClient.set_param(self._currentGroupKey, param, value)
+        param = self._models[self._current_group_key].item(top_left.row(), 0).text()
+        self._param_client.set_param(self._current_group_key, param, value)
 
         # Add the new value to the previous values list
-        if self._addChangedValuesToHist:
-            self._valueStack[(self._currentGroupKey, param)].append(value)
+        if self._add_changed_values_to_hist:
+            self._value_stack[(self._current_group_key, param)].append(value)
 
         # Update the buttons with the new previous value
         # Creating all new buttons is inefficient, but it is the easiest and most consistent way to update the values
-        self._createTableButtons()
+        self._create_table_buttons()
 
-    def registerPlotSwapCallback(self, callback: callable) -> None:
-        self._plotSwapCallback = callback
+    def register_plot_swap_callback(self, callback: callable) -> None:
+        self._plot_swap_callback = callback

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_widget.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_widget.py
@@ -9,13 +9,12 @@ from python_qt_binding.QtWidgets import QWidget, QPushButton, QFileDialog
 
 
 class ParamTuningWidget(QWidget):
-    def __init__(self, config: dict, paramClient, paramFilepath: str, x_length: float):
-        self._paramFilePath = paramFilepath
-
+    def __init__(self, config: dict, paramClient, paramFilepath: str):
         # Initialize widget
         super(ParamTuningWidget, self).__init__()
         self.setObjectName('ParamTuningWidget')
         self._addChangedValuesToHist = True
+        self._plotSwapCallback = lambda x: None
 
         # Load the UI file
         _, path = get_resource('packages', 'rosflight_rqt_plugins')
@@ -152,6 +151,9 @@ class ParamTuningWidget(QWidget):
         self._createTableButtons()
         self._refreshTableValues()
 
+        # Tell the plotter to swap the plot
+        self._plotSwapCallback(text)
+
     def _refreshButtonCallback(self):
         self._refreshTableValues()
 
@@ -213,3 +215,6 @@ class ParamTuningWidget(QWidget):
         # Update the buttons with the new previous value
         # Creating all new buttons is inefficient, but it is the easiest and most consistent way to update the values
         self._createTableButtons()
+
+    def registerPlotSwapCallback(self, callback: callable) -> None:
+        self._plotSwapCallback = callback

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_widget.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_widget.py
@@ -37,12 +37,12 @@ class ParamTuningWidget(QWidget):
 
         # Set up the widget
         # Group selection - QComboBox
-        self.groupSelection.addItems(self._config.keys())
-        self.groupSelection.currentTextChanged.connect(self._groupSelectionCallback)
+        self.group_selection.addItems(self._config.keys())
+        self.group_selection.currentTextChanged.connect(self._groupSelectionCallback)
         # Refresh button - QPushButton
-        self.refreshButton.clicked.connect(self._refreshButtonCallback)
+        self.refresh_button.clicked.connect(self._refreshButtonCallback)
         # Save to file button - QPushButton
-        self.saveButton.clicked.connect(self._saveButtonCallback)
+        self.save_button.clicked.connect(self._saveButtonCallback)
         # Parameter table - QTableView
         self._setupTableModels()
         self._createTableButtons()
@@ -66,17 +66,17 @@ class ParamTuningWidget(QWidget):
             self._models[group] = model
 
         # Load the first model into the table
-        self.paramTableView.setModel(self._models[self._currentGroupKey])
+        self.param_table_view.setModel(self._models[self._currentGroupKey])
 
         # Set the column widths
         for i, width in enumerate(self._tableWidths):
-            self.paramTableView.setColumnWidth(i, width)
+            self.param_table_view.setColumnWidth(i, width)
 
         # Hide the number row
-        self.paramTableView.verticalHeader().hide()
+        self.param_table_view.verticalHeader().hide()
 
         # Connect the model change signal
-        self.paramTableView.model().dataChanged.connect(self._onModelChange)
+        self.param_table_view.model().dataChanged.connect(self._onModelChange)
 
     def _createTableButtons(self):
         # Get a list of gains for the current group
@@ -93,16 +93,16 @@ class ParamTuningWidget(QWidget):
             button.clicked.connect(
                 lambda _, g=self._currentGroupKey, index=i, p=param: self._resetPreviousButtonCallback(g, index, p)
             )
-            index = self.paramTableView.model().index(i, 3)
-            self.paramTableView.setIndexWidget(index, button)
+            index = self.param_table_view.model().index(i, 3)
+            self.param_table_view.setIndexWidget(index, button)
 
             # Create reset to original buttons
             button = QPushButton(str(self._valueStack[(self._currentGroupKey, param)][0]))
             button.clicked.connect(
                 lambda _, g=self._currentGroupKey, index=i, p=param: self._resetInitialButtonCallback(g, index, p)
             )
-            index = self.paramTableView.model().index(i, 4)
-            self.paramTableView.setIndexWidget(index, button)
+            index = self.param_table_view.model().index(i, 4)
+            self.param_table_view.setIndexWidget(index, button)
 
     def _resetPreviousButtonCallback(self, group, row, param):
         # Pop the last value from list, unless it is the last value
@@ -124,7 +124,7 @@ class ParamTuningWidget(QWidget):
         self._paramClient.print_info('Getting all parameters from ROS network...')
 
         # Temporarily disconnect the model change signal
-        self.paramTableView.model().dataChanged.disconnect(self._onModelChange)
+        self.param_table_view.model().dataChanged.disconnect(self._onModelChange)
 
         # Get current values of the parameters
         for group in self._config:
@@ -141,15 +141,15 @@ class ParamTuningWidget(QWidget):
                 self._models[group].item(i, 1).setText(str(value))
 
         # Reconnect the model change signal
-        self.paramTableView.model().dataChanged.connect(self._onModelChange)
+        self.param_table_view.model().dataChanged.connect(self._onModelChange)
 
     def _groupSelectionCallback(self, text):
         self._currentGroupKey = text
 
         # Swap models and connect the model change signal to the new model
-        self.paramTableView.model().dataChanged.disconnect(self._onModelChange)
-        self.paramTableView.setModel(self._models[text])
-        self.paramTableView.model().dataChanged.connect(self._onModelChange)
+        self.param_table_view.model().dataChanged.disconnect(self._onModelChange)
+        self.param_table_view.setModel(self._models[text])
+        self.param_table_view.model().dataChanged.connect(self._onModelChange)
 
         # Update table
         self._createTableButtons()
@@ -206,11 +206,11 @@ class ParamTuningWidget(QWidget):
             self._paramClient.print_warning('Invalid value type, please enter a number.')
 
             # Restore the previous value
-            self.paramTableView.model().dataChanged.disconnect(self._onModelChange)
-            self.paramTableView.model().itemFromIndex(topLeft).setText(str(
+            self.param_table_view.model().dataChanged.disconnect(self._onModelChange)
+            self.param_table_view.model().itemFromIndex(topLeft).setText(str(
                 self._valueStack[(self._currentGroupKey,
                                   self._models[self._currentGroupKey].item(topLeft.row(), 0).text())][-1]))
-            self.paramTableView.model().dataChanged.connect(self._onModelChange)
+            self.param_table_view.model().dataChanged.connect(self._onModelChange)
             return
 
         # Set the new value

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_widget.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_widget.py
@@ -9,7 +9,7 @@ from python_qt_binding.QtWidgets import QWidget, QPushButton, QFileDialog
 
 
 class ParamTuningWidget(QWidget):
-    def __init__(self, config: dict, paramClient, paramFilepath):
+    def __init__(self, config: dict, paramClient, paramFilepath: str, x_length: float):
         self.paramFilePath = paramFilepath
 
         # Initialize widget

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_widget.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_widget.py
@@ -15,8 +15,11 @@ class ParamTuningWidget(QWidget):
         self.setObjectName('ParamTuningWidget')
         self._param_file_path = param_filepath
         self._add_changed_values_to_hist = True
+
+        # Define external callbacks
         self._external_plot_swap_callback = lambda x: None
         self._external_duration_change_callback = lambda x: None
+        self._external_pause_plot_callback = lambda x: None
 
         # Load the UI file
         _, path = get_resource('packages', 'rosflight_rqt_plugins')
@@ -46,6 +49,8 @@ class ParamTuningWidget(QWidget):
         self.save_button.clicked.connect(self._save_button_callback)
         # Duration spin box
         self.time_duration_spin_box.valueChanged.connect(self._duration_spin_box_change_callback)
+        # Paused checkbox
+        self.pause_plot_check_box.stateChanged.connect(self._pause_box_change_callback)
         # Parameter table - QTableView
         self._setupTableModels()
         self._create_table_buttons()
@@ -231,9 +236,17 @@ class ParamTuningWidget(QWidget):
     def _duration_spin_box_change_callback(self, value):
         self._external_duration_change_callback(float(value))
 
+    def _pause_box_change_callback(self, value):
+        value = True if value == 2 else False
+        self._external_pause_plot_callback(value)
+
     def register_plot_swap_callback(self, callback: callable) -> None:
         self._external_plot_swap_callback = callback
 
     def register_duration_change_callback(self, callback: callable) -> None:
         self._external_duration_change_callback = callback
         callback(self.time_duration_spin_box.value())
+
+    def register_pause_plot_callback(self, callback: callable) -> None:
+        self._external_pause_plot_callback = callback
+        callback(self.pause_plot_check_box.isChecked())

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_widget.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_widget.py
@@ -13,6 +13,7 @@ class ParamTuningWidget(QWidget):
         # Initialize widget
         super(ParamTuningWidget, self).__init__()
         self.setObjectName('ParamTuningWidget')
+        self._paramFilePath = paramFilepath
         self._addChangedValuesToHist = True
         self._plotSwapCallback = lambda x: None
 

--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning_widget.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning_widget.py
@@ -15,7 +15,8 @@ class ParamTuningWidget(QWidget):
         self.setObjectName('ParamTuningWidget')
         self._param_file_path = param_filepath
         self._add_changed_values_to_hist = True
-        self._plot_swap_callback = lambda x: None
+        self._external_plot_swap_callback = lambda x: None
+        self._external_duration_change_callback = lambda x: None
 
         # Load the UI file
         _, path = get_resource('packages', 'rosflight_rqt_plugins')
@@ -43,6 +44,8 @@ class ParamTuningWidget(QWidget):
         self.refresh_button.clicked.connect(self._refresh_button_callback)
         # Save to file button - QPushButton
         self.save_button.clicked.connect(self._save_button_callback)
+        # Duration spin box
+        self.time_duration_spin_box.valueChanged.connect(self._duration_spin_box_change_callback)
         # Parameter table - QTableView
         self._setupTableModels()
         self._create_table_buttons()
@@ -155,7 +158,7 @@ class ParamTuningWidget(QWidget):
         self._create_table_buttons()
 
         # Tell the plotter to swap the plot
-        self._plot_swap_callback(text)
+        self._external_plot_swap_callback(text)
 
     def _refresh_button_callback(self):
         self._refresh_table_values()
@@ -225,5 +228,12 @@ class ParamTuningWidget(QWidget):
         # Creating all new buttons is inefficient, but it is the easiest and most consistent way to update the values
         self._create_table_buttons()
 
+    def _duration_spin_box_change_callback(self, value):
+        self._external_duration_change_callback(float(value))
+
     def register_plot_swap_callback(self, callback: callable) -> None:
-        self._plot_swap_callback = callback
+        self._external_plot_swap_callback = callback
+
+    def register_duration_change_callback(self, callback: callable) -> None:
+        self._external_duration_change_callback = callback
+        callback(self.time_duration_spin_box.value())


### PR DESCRIPTION
To improve the autopilot tuning experience, I added a plotter to the rqt-based tuning GUI. The plotter is dynamically populated with the same .yaml file that populates the parameter adjustment table. The plot correlates with the current tuning group, and if you switch which parameters you're tuning then the plot you're viewing also changes.

There are a few other things you can configure in the .yaml file, but that is explained in the example .yaml file.

![Screenshot from 2024-07-17 14-59-29](https://github.com/user-attachments/assets/75a40411-8889-4790-a2b8-ca86d55427f6)
