### PR TITLE
ParamTuning RQT GUI config file loading

### DIFF
--- a/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
+++ b/rosflight_rqt_plugins/src/param_tuning/param_tuning.py
@@ -29,6 +29,8 @@ class ParamTuning(Plugin):
                 self._node.get_logger().fatal('No configuration file selected, please provide a configuration file like'
                                               ' rosflight_rqt_plugins/resources/example_config.yaml')
                 raise RuntimeError('No configuration file provided')
+            
+            args.config_filepath = filename
         with open(args.config_filepath, 'r') as file:
             self._config = yaml.safe_load(file)
 


### PR DESCRIPTION
This pull request is to merge a bug fix that occurred when selecting a config file from the file explorer window. 

The other option is to pass the config file path in through command line arguments, and that was working. This change does not affect that functionality.