### PR TITLE
Multirotor updates to sim packages and SIL board

### DIFF
--- a/rosflight_rqt_plugins/resources/param_tuning_multirotor.yaml
+++ b/rosflight_rqt_plugins/resources/param_tuning_multirotor.yaml
@@ -1,0 +1,125 @@
+# Example configuration file to set up the parameter tuning interface. All GUI elements are
+# populated based on this file. This example is written as if it was for use with ROSplane.
+#
+# {Name of parameter group}:
+#   node: '/{ROS_node_name}'
+#   params:
+#     {param_name}:
+#       description: '{Parameter description}'
+#       scale: {Scale factor to use with parameters}  (optional, default is 1.0)
+#     ...
+#   (Everything below this is optional if you don't want to plot data)
+#   plot_topics:
+#     {Plot name}:
+#       topic: '/{ROS_topic_name}/{field_name}'
+#       scale: {Scale factor to use with data}  (optional, default is 1.0)
+#     ...
+#   plot_axis_label: '{Y Axis Label}'  (x axis is always 'Time (s)')
+#   plot_axis_range: [min, max]  (optional, default is auto scaling)
+# ...
+
+
+North Position:
+  node: '/autopilot'
+  params:
+    u_n_kp:
+      description: 'North position P gain'
+    u_n_ki:
+      description: 'North position I gain'
+    u_n_kd:
+      description: 'North position D gain'
+  plot_topics:
+    North State:
+      topic: '/state/position[0]'
+      scale: 1.0
+    North Command:
+      topic: '/high_level_command/cmd1'
+      scale: 1.0
+  plot_axis_label: 'Roll angle (deg)'
+  plot_axis_range: [-30, 30]
+
+East Position:
+  node: '/autopilot'
+  params:
+    u_e_kp:
+      description: 'East position P gain'
+    u_e_ki:
+      description: 'East position I gain'
+    u_e_kd:
+      description: 'East position D gain'
+  plot_topics:
+    East State:
+      topic: '/state/position[1]'
+      scale: 1.0
+  plot_axis_label: 'Roll angle (deg)'
+  plot_axis_range: [-30, 30]
+
+Down Position:
+  node: '/autopilot'
+  params:
+    u_d_kp:
+      description: 'Down position P gain'
+    u_d_ki:
+      description: 'Down position I gain'
+    u_d_kd:
+      description: 'Down position D gain'
+  plot_topics:
+    Down State:
+      topic: '/state/position[2]'
+      scale: 1.0
+    Down Command:
+      topic: '/high_level_command/cmd3'
+      scale: 1.0
+  plot_axis_label: 'Roll angle (deg)'
+  plot_axis_range: [-60, 1]
+
+Roll Angle:
+  node: '/autopilot'
+  params:
+    phi_kp:
+      description: 'Roll P gain'
+    phi_ki:
+      description: 'Roll I gain'
+    phi_kd:
+      description: 'Roll D gain'
+  plot_topics:
+    Roll State:
+      topic: '/state/phi'
+      scale: 57.2957795131
+    Roll Command:
+      topic: '/high_level_command/phi_c'
+      scale: 57.2957795131
+  plot_axis_label: 'Roll angle (deg)'
+  plot_axis_range: [-30, 30]
+
+Pitch Angle:
+  node: '/autopilot'
+  params:
+    theta_kp:
+      description: 'Theta P gain'
+    theta_ki:
+      description: 'Theta I gain'
+    theta_kd:
+      description: 'Theta D gain'
+  plot_topics:
+    Pitch State:
+      topic: '/state/theta'
+      scale: 1.0
+  plot_axis_label: 'Pitch angle (deg)'
+  plot_axis_range: [-30, 30]
+
+Yaw Angle:
+  node: '/autopilot'
+  params:
+    psi_kp:
+      description: 'Yaw P gain'
+    psi_ki:
+      description: 'Yaw I gain'
+    psi_kd:
+      description: 'Yaw D gain'
+  plot_topics:
+    Yaw State:
+      topic: '/state/psi'
+      scale: 1.0
+  plot_axis_label: 'Yaw angle (deg)'
+  plot_axis_range: [-30, 30]

--- a/rosflight_sim/include/rosflight_sim/sil_board.hpp
+++ b/rosflight_sim/include/rosflight_sim/sil_board.hpp
@@ -370,6 +370,15 @@ public:
    */
   void pwm_init(uint32_t refresh_rate, uint16_t idle_pwm) override;
   /**
+   * @brief Initializes RC PWM values to idle values.
+   *
+   * @note Calls pwm_init method. Parameters are not used in SIL board.
+   *
+   * @param rate The refresh rate of the channel
+   * @param channels The number of channels to write to.
+   */
+  void pwm_init_multi(const float *rate, uint32_t channels) override;
+  /**
    * @brief Writes PWM value to given channel, from a value between 0 and 1. The value is scaled to
    * 1000 to 2000 and then written to the channel.
    *
@@ -377,6 +386,13 @@ public:
    * @param value Value between 0 and 1, to write to channel.
    */
   void pwm_write(uint8_t channel, float value) override;
+  /**
+   * @brief Writes PWM value to given channels, using pwm_write method. 
+   *
+   * @param channel Channel to write PWM to.
+   * @param value Array of values between 0 and 1, to write to channel.
+   */
+  void pwm_write_multi(float *value, uint32_t channels) override;
   /**
    * @brief Sets all PWM values to 1000.
    */

--- a/rosflight_sim/launch/multirotor.launch.py
+++ b/rosflight_sim/launch/multirotor.launch.py
@@ -32,7 +32,7 @@ def generate_launch_description():
     )
     z = LaunchConfiguration('z')
     z_launch_arg = DeclareLaunchArgument(
-        'z', default_value=TextSubstitution(text='0.1')
+        'z', default_value=TextSubstitution(text='0.2')
     )
     yaw = LaunchConfiguration('yaw')
     yaw_launch_arg = DeclareLaunchArgument(
@@ -48,12 +48,12 @@ def generate_launch_description():
     )
     verbose = LaunchConfiguration('verbose')
     verbose_launch_arg = DeclareLaunchArgument(
-        'verbose', default_value=TextSubstitution(text='false')
+        'verbose', default_value=TextSubstitution(text='true')
     )
     world_file = LaunchConfiguration('world_file')
     world_file_launch_arg = DeclareLaunchArgument(
         'world_file', default_value=TextSubstitution(text=os.path.join(
-            get_package_share_directory('rosflight_sim'), 'resources/empty-asphalt.world'
+            get_package_share_directory('rosflight_sim'), 'resources', 'runway.world'
         ))
     )
     tf_prefix = LaunchConfiguration('tf_prefix')
@@ -86,18 +86,18 @@ def generate_launch_description():
             'gui': gui,
             'verbose': verbose,
             'world': world_file,
-            'params_file': os.path.join(get_package_share_directory('rosflight_sim'), 'params/multirotor_dynamics.yaml'),
+            'params_file': os.path.join(get_package_share_directory('rosflight_sim'), 'params', 'multirotor_dynamics.yaml'),
         }.items()
     )
 
     # Render xacro file
-    xacro_filepath_string = os.path.join(get_package_share_directory('rosflight_sim'), 'xacro/multirotor.urdf.xacro')
-    urdf_filepath_string = os.path.join(get_package_share_directory('rosflight_sim'), 'resources/multirotor.urdf')
+    xacro_filepath_string = os.path.join(get_package_share_directory('rosflight_sim'), 'xacro', 'multirotor.urdf.xacro')
+    urdf_filepath_string = os.path.join(get_package_share_directory('rosflight_sim'), 'resources', 'multirotor.urdf')
     robot_description = xacro.process_file(
         xacro_filepath_string, mappings={
             'mesh_file_location': os.path.join(
                 get_package_share_directory('rosflight_sim'),
-                'resources/multirotor.dae'
+                'resources', 'multirotor.dae'
             )
         }
     ).toxml()

--- a/rosflight_sim/launch/multirotor.launch.py
+++ b/rosflight_sim/launch/multirotor.launch.py
@@ -48,7 +48,7 @@ def generate_launch_description():
     )
     verbose = LaunchConfiguration('verbose')
     verbose_launch_arg = DeclareLaunchArgument(
-        'verbose', default_value=TextSubstitution(text='true')
+        'verbose', default_value=TextSubstitution(text='false')
     )
     world_file = LaunchConfiguration('world_file')
     world_file_launch_arg = DeclareLaunchArgument(

--- a/rosflight_sim/params/multirotor_firmware.yaml
+++ b/rosflight_sim/params/multirotor_firmware.yaml
@@ -1,8 +1,8 @@
 - {name: RC_NUM_CHN, type: 6, value: 8}
 - {name: ARM_CHANNEL, type: 6, value: 4}
+- {name: RC_THR_OVRD_CHN, type: 6, value: 5} # Set pilot override channel for throttle control.
+- {name: RC_ATT_OVRD_CHN, type: 6, value: 6} # Set pilot override channel for attitude control.
 - {name: MIXER, type: 6, value: 2}
 - {name: FAILSAFE_THR, type: 9, value: 0.0}
-- {name: RC_ATT_CTRL_CHN, type: 6, value: 6}
-- {name: RC_THR_OVRD_CHN, type: 6, value: 5} # Set pilot override channel for throttle control.
-- {name: RC_ATT_OVRD_CHN, type: 6, value: 5} # Set pilot override channel for attitude control.
 - {name: MIN_THROTTLE, type: 6, value: 0}    # Don't take minimum of RC and offboard at all times
+  # - {name: RC_ATT_CTRL_CHN, type: 6, value: 7}

--- a/rosflight_sim/params/multirotor_firmware.yaml
+++ b/rosflight_sim/params/multirotor_firmware.yaml
@@ -1,3 +1,4 @@
 - {name: ARM_CHANNEL, type: 6, value: 4}
-- {name: MIXER, type: 6, value: 1}
+- {name: MIXER, type: 6, value: 2}
 - {name: FAILSAFE_THR, type: 9, value: 0.0}
+- {name: RC_ATT_CTRL_CHN, type: 6, value: 5}

--- a/rosflight_sim/params/multirotor_firmware.yaml
+++ b/rosflight_sim/params/multirotor_firmware.yaml
@@ -1,4 +1,8 @@
+- {name: RC_NUM_CHN, type: 6, value: 8}
 - {name: ARM_CHANNEL, type: 6, value: 4}
 - {name: MIXER, type: 6, value: 2}
 - {name: FAILSAFE_THR, type: 9, value: 0.0}
-- {name: RC_ATT_CTRL_CHN, type: 6, value: 5}
+- {name: RC_ATT_CTRL_CHN, type: 6, value: 6}
+- {name: RC_THR_OVRD_CHN, type: 6, value: 5} # Set pilot override channel for throttle control.
+- {name: RC_ATT_OVRD_CHN, type: 6, value: 5} # Set pilot override channel for attitude control.
+- {name: MIN_THROTTLE, type: 6, value: 0}    # Don't take minimum of RC and offboard at all times

--- a/rosflight_sim/src/sil_board.cpp
+++ b/rosflight_sim/src/sil_board.cpp
@@ -573,6 +573,13 @@ void SILBoard::pwm_init(uint32_t refresh_rate, uint16_t idle_pwm)
     "/forces_and_moments", 1, std::bind(&SILBoard::forces_callback, this, std::placeholders::_1));
 }
 
+void SILBoard::pwm_init_multi(const float *rate, uint32_t channels)
+{
+  // Only call it once, since we don't set the rate for each channel differently in the SIM board.
+  // This works since the pwm_init doesn't use the arguments passed to it (in the SIL board)
+  pwm_init(0, 0);
+}
+
 void SILBoard::forces_callback(const geometry_msgs::msg::TwistStamped & msg)
 {
 
@@ -599,6 +606,14 @@ void SILBoard::pwm_write(uint8_t channel, float value)
 {
   pwm_outputs_[channel] = 1000 + (uint16_t) (1000 * value);
 }
+
+void SILBoard::pwm_write_multi(float *value, uint32_t channels)
+{
+  for (int i=0; i<(int) channels; ++i) {
+    pwm_write(i, value[i]);
+  }
+}
+
 void SILBoard::pwm_disable()
 {
   for (int i = 0; i < 14; i++) {


### PR DESCRIPTION
I changed the default gazebo world to the runway world so it was easier to see where the multirotor is. Also tweaked some of the gazebo launch arguments so it would spawn correctly. 

Also added updated definitions from `board.h` to the `sil_board` so we could use the latest commits of the firmware.