### PR TITLE
Vim Fly - A keyboard controller for the rosflight sim

### DIFF
--- a/rosflight_sim/include/rosflight_sim/multirotor_forces_and_moments.hpp
+++ b/rosflight_sim/include/rosflight_sim/multirotor_forces_and_moments.hpp
@@ -38,6 +38,8 @@
 #include <eigen3/Eigen/Dense>
 #include <rclcpp/rclcpp.hpp>
 
+#include <geometry_msgs/msg/twist_stamped.hpp>
+
 #include <rosflight_sim/mav_forces_and_moments.hpp>
 
 namespace rosflight_sim
@@ -104,6 +106,8 @@ public:
    */
   explicit Multirotor(rclcpp::Node::SharedPtr node);
   ~Multirotor();
+
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr forces_moments_pub_;
 
   /**
    * @brief Calculates forces and moments based on current state and aerodynamic forces.

--- a/rosflight_sim/launch/multirotor_sim_io_joy.launch.py
+++ b/rosflight_sim/launch/multirotor_sim_io_joy.launch.py
@@ -7,16 +7,25 @@ Description: ROS2 launch file used to launch multirotor SIL, rosflight_io, and r
 """
 
 import os
+import sys
 
 from ament_index_python import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
     """This is a launch file that runs the bare minimum requirements fly a multirotor in gazebo"""
+
+    use_vimfly = False
+
+    for arg in sys.argv:
+        if arg.startswith("use_vimfly:="):
+            use_vimfly = arg.split(":=")[1]
+            use_vimfly = use_vimfly.lower() == 'true'
 
     # Start simulator
     simulator_launch_include = IncludeLaunchDescription(
@@ -44,6 +53,9 @@ def generate_launch_description():
         executable='rc.py',
         remappings=[
             ('/RC', '/multirotor/RC')
+        ],
+        parameters=[ 
+            {'use_vimfly': use_vimfly}
         ]
     )
 

--- a/rosflight_sim/src/multirotor_forces_and_moments.cpp
+++ b/rosflight_sim/src/multirotor_forces_and_moments.cpp
@@ -139,6 +139,10 @@ Multirotor::Multirotor(rclcpp::Node::SharedPtr node)
   }
 
   wind_ = Eigen::Vector3d::Zero();
+
+  forces_moments_pub_ =
+    node_->create_publisher<geometry_msgs::msg::TwistStamped>("/forces_and_moments", 1);
+
   prev_time_ = -1;
 }
 
@@ -216,6 +220,22 @@ Eigen::Matrix<double, 6, 1> Multirotor::update_forces_and_torques(CurrentState x
 
   // Apply ground effect and thrust
   forces(2) += output_forces_and_torques(3) - ground_effect;
+  
+  geometry_msgs::msg::TwistStamped msg;
+
+  rclcpp::Time now = node_->get_clock()->now();
+
+  msg.header.stamp = now;
+
+  msg.twist.linear.x = forces(0);
+  msg.twist.linear.y = forces(1);
+  msg.twist.linear.z = forces(2);
+
+  msg.twist.angular.x = forces(3);
+  msg.twist.angular.y = forces(4);
+  msg.twist.angular.z = forces(5);
+
+  forces_moments_pub_->publish(msg);
 
   return forces;
 }

--- a/rosflight_sim/src/rc.py
+++ b/rosflight_sim/src/rc.py
@@ -155,7 +155,7 @@ class RC(Node):
             self.get_logger().info('No joystick (or display) detected, using simulated joystick')
             self.transmitter_detected = False
         
-        self.declare_parameter('use_vimfly', True)
+        self.declare_parameter('use_vimfly', False)
         self.use_vimfly = self.get_parameter('use_vimfly').get_parameter_value().bool_value
 
         if self.use_vimfly and not self.transmitter_detected:

--- a/rosflight_sim/src/rc.py
+++ b/rosflight_sim/src/rc.py
@@ -157,7 +157,8 @@ class RC(Node):
         
         self.declare_parameter('use_vimfly', False)
         self.use_vimfly = self.get_parameter('use_vimfly').get_parameter_value().bool_value
-
+        
+        # Intercept if using VimFly.
         if self.use_vimfly and not self.transmitter_detected:
             self.get_logger().info('Using VimFly...')
             self.vim_fly = VimFly()
@@ -165,7 +166,6 @@ class RC(Node):
         
         self.rc_publisher = self.create_publisher(RCRaw, 'RC', 10)
         self.timer = self.create_timer(1.0 / 50, self.timer_callback)
-
 
         # Transmitter detected, initialize joystick
         if self.transmitter_detected:
@@ -187,7 +187,7 @@ class RC(Node):
                 self.transmitter_detected = False
 
         # Transmitter not detected, use simulated joystick
-        if not self.transmitter_detected and not self.use_vimfly:
+        if not self.transmitter_detected:
             self.THROTTLE_CHANNEL = 2
             self.ARM_SWITCH_CHANNEL = 4
             self.OVERRIDE_CHANNEL = 5

--- a/rosflight_sim/src/vimfly.py
+++ b/rosflight_sim/src/vimfly.py
@@ -38,7 +38,7 @@ class VimFly:
         self.font = pygame.font.SysFont("monospace", 18)
 
         # create publisher for RC commands.
-        self.rc_pub = self.node.create_publisher(RCRaw, 'multirotor/RC', 10)
+        self.rc_pub = self.node.create_publisher(RCRaw, 'RC', 10)
         
         # TODO: swap these hardcoded vals to params
         self.rate = 30

--- a/rosflight_sim/src/vimfly.py
+++ b/rosflight_sim/src/vimfly.py
@@ -38,12 +38,12 @@ class VimFly:
         self.thrust_start_time = self.node.get_clock().now()
 
         self.armed = 1000 # Unarmed
-        self.ARM_DEBOUNCE_THRESHOLD = 0.250
+        self.ARM_DEBOUNCE_THRESHOLD = 0.500
         self.arm_debouncing = [False]
         self.arm_start_time = self.node.get_clock().now()
 
         self.RC_override = 2000 # Start under manual control
-        self.RC_OVERRIDE_DEBOUNCE_THRESHOLD = 0.250
+        self.RC_OVERRIDE_DEBOUNCE_THRESHOLD = 0.500
         self.RC_override_debouncing = [False]
         self.RC_override_start_time = self.node.get_clock().now()
 

--- a/rosflight_sim/src/vimfly.py
+++ b/rosflight_sim/src/vimfly.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python
+"""
+vimfly - vim keybindings for your multirotor!
+
+Teleoperated flying from your keyboard. Command u, v, psidot, and altitude.
+
+The following keybindings are used:
+    - a: lower altitude
+    - s: higher altitude
+    - d: CCW (-psidot)
+    - f: CW (+psidot)
+    - h: Left (-v)
+    - j: Backward (-u)
+    - k: Forward (+u)
+    - l: Right (+v)
+
+Connect to rosflight_io command topic (SIL/HW) or roscopter_sim Gazebo command
+topic.
+
+
+https://xkcd.com/1823/
+"""
+import pygame
+import rclpy
+import time
+from rosflight_msgs.msg import RCRaw
+
+
+class VimFly:
+    def __init__(self):
+
+        self.node = rclpy.create_node('vimfly')
+
+        # initialize pygame display
+        pygame.init()
+        pygame.display.set_caption('vimfly')
+        self.screen = pygame.display.set_mode((550, 200))
+        self.font = pygame.font.SysFont("monospace", 18)
+
+        # create publisher for RC commands.
+        self.rc_pub = self.node.create_publisher(RCRaw, 'multirotor/RC', 10)
+        
+        # TODO: swap these hardcoded vals to params
+        self.rate = 30
+
+        # self.timer = self.node.create_timer(1/self.rate, self.run)
+
+        self.thrust_command = 1000
+        self.thrust_step = 10
+        self.THRUST_DEBOUNCE_THRESHOLD = 0.100
+        self.thrust_debouncing = [False]
+        self.thrust_start_time = self.node.get_clock().now()
+
+        self.armed = 1000 # Unarmed
+        self.ARM_DEBOUNCE_THRESHOLD = 0.250
+        self.arm_debouncing = [False]
+        self.arm_start_time = self.node.get_clock().now()
+
+        self.RC_override = 2000 # Start under manual control
+        self.RC_OVERRIDE_DEBOUNCE_THRESHOLD = 0.250
+        self.RC_override_debouncing = [False]
+        self.RC_override_start_time = self.node.get_clock().now()
+
+        while(True):
+            self.keys = pygame.key.get_pressed()
+            self.run()
+            time.sleep(1/self.rate)
+
+
+    def run(self):
+
+        # initialize command message
+        msg = RCRaw()
+        msg.header.stamp = self.node.get_clock().now().to_msg()
+
+        # LEFT -- h
+        if self.keys[pygame.K_h]:
+            msg.values[0] = 2000
+
+        # RIGHT -- l
+        elif self.keys[pygame.K_l]:
+            msg.values[0] = 1000
+
+        else:
+            msg.values[0] = 1500
+
+        # FORWARD -- k
+        if self.keys[pygame.K_k]:
+            msg.values[1] = 2000
+
+        # BACKWARD -- j
+        elif self.keys[pygame.K_j]:
+            msg.values[1] = 1000
+
+        else:
+            msg.values[1] = 1500
+
+        # CCW -- d
+        if self.keys[pygame.K_d]:
+            msg.values[3] = 2000
+
+        # CW -- f
+        elif self.keys[pygame.K_f]:
+            msg.values[3] = 1000
+
+        else:
+            msg.values[3] = 1500
+
+        # THRUST LOWER -- s  //  THRUST HIGHER -- a
+        if self.keys[pygame.K_a] or self.keys[pygame.K_s]:
+            self.debounce(self.thrust_debouncing, self.thrust_start_time, self.THRUST_DEBOUNCE_THRESHOLD, self.increment_thrust)
+        else:
+            self.thrust_debouncing[0] = False
+
+        # Always send an thrust command -- we don't want to drop like a brick!
+        msg.values[2] = self.thrust_command
+        
+        # Send arm commands
+        if self.keys[pygame.K_t]:
+            self.debounce(self.arm_debouncing, self.arm_start_time, self.ARM_DEBOUNCE_THRESHOLD, self.toggle_arm)
+        else:
+            self.arm_debouncing[0] = False
+
+        msg.values[4] = self.armed
+        
+        # Send RC override commands
+        if self.keys[pygame.K_r]:
+            self.debounce(self.RC_override_debouncing, self.RC_override_start_time, self.RC_OVERRIDE_DEBOUNCE_THRESHOLD, self.toggle_RC_override)
+        else:
+            self.RC_override_debouncing[0] = False
+        
+        msg.values[5] = self.RC_override
+
+        # Pad the message with remaining channels.
+        msg.values[6] = 1500
+        msg.values[7] = 1500
+
+        # Publish commands
+        self.rc_pub.publish(msg)
+
+        # Update the display with the current commands
+        self.update_display(msg)
+
+        # process event queue and throttle the while loop
+        pygame.event.pump()
+
+
+    def update_display(self, msg):
+        self.display_help()
+
+        msgText = "roll: {}, pitch: {}, yaw: {}, thrust: {}".format(msg.values[0], msg.values[1], msg.values[3], msg.values[2])
+
+        status_info = "armed: {}, RC_override: {}".format(msg.values[4], msg.values[5])
+        self.render(msgText, (0,140))
+        self.render(status_info, (100,160))
+        
+        pygame.display.flip()
+
+
+    def display_help(self):
+        self.screen.fill((0,0,0))
+
+        LINE=20
+
+        self.render("vimfly keybindings:", (0,0))
+        self.render("- a: higher thrust", (0,1*LINE)); self.render("- h: Roll Left", (250,1*LINE))
+        self.render("- s: lower thrust", (0,2*LINE)); self.render("- j: Pitch Backward", (250,2*LINE))
+        self.render("- d: yaw CCW", (0,3*LINE)); self.render("- k: Pitch Forward", (250,3*LINE))
+        self.render("- f: yaw CW", (0,4*LINE)); self.render("- l: Roll Right", (250,4*LINE))
+        self.render("- t: arm/disarm", (0,5*LINE)); self.render("- r: RC override", (250,5*LINE))
+
+
+    def render(self, text, loc):
+        txt = self.font.render(text, 1, (255,255,255))
+        self.screen.blit(txt, loc)
+
+    def debounce(self, debounced, debounce_start_time, threshold, key_action):
+
+        if not debounced[0]:
+            debounced[0] = True
+            debounce_start_time = self.node.get_clock().now()
+
+        if (self.node.get_clock().now() - debounce_start_time).nanoseconds / 1e9 > threshold:
+            
+            # The key has been debounced once, start the process over!
+            debounced[0] = False
+
+            key_action()
+
+    def increment_thrust(self):
+        # Increment the commanded altitude
+        if self.keys[pygame.K_a] and self.thrust_command < 2000:
+            self.thrust_command += self.thrust_step
+
+        elif self.keys[pygame.K_s] and self.thrust_command > 1000:
+            self.thrust_command -= self.thrust_step
+
+    def toggle_arm(self):
+            if self.armed == 1000:
+                self.armed = 2000
+            else:
+                self.armed = 1000
+    
+    def toggle_RC_override(self):
+            if self.RC_override == 1000:
+                self.RC_override = 2000
+            else:
+                self.RC_override = 1000
+
+if __name__ == '__main__':
+    rclpy.init()
+    teleop = VimFly()

--- a/rosflight_sim/src/vimfly.py
+++ b/rosflight_sim/src/vimfly.py
@@ -2,23 +2,9 @@
 """
 vimfly - vim keybindings for your multirotor!
 
-Teleoperated flying from your keyboard. Command u, v, psidot, and altitude.
+Teleoperated flying from your keyboard.
+Keys are mapped to each channel of the RCRaw message.
 
-The following keybindings are used:
-    - a: lower altitude
-    - s: higher altitude
-    - d: CCW (-psidot)
-    - f: CW (+psidot)
-    - h: Left (-v)
-    - j: Backward (-u)
-    - k: Forward (+u)
-    - l: Right (+v)
-
-Connect to rosflight_io command topic (SIL/HW) or roscopter_sim Gazebo command
-topic.
-
-
-https://xkcd.com/1823/
 """
 import pygame
 import rclpy


### PR DESCRIPTION
This is ported from the roscopter repo in the BYU-Magicc org. It uses the vim keybindings for raw RC output. It can be jerky but it works to fly multi-rotors and fixedwings. You can't fly super well but it is good enough to allow for testing without the need for a controller.

It launches vimfly if the param is set to use it and if a controller is not detected. However, rc.py does not have a param file it uses, and I didn't want to add one for a single param. So to enable  VimFly you have to edit the default param value in the rc.py file. This is because the param has to be initialized at launch. If you have a better idea of how to implement this let me know!