### PR TITLE
195 plane acts erratically under computer or manual control    v tail mixer issues in the simulation

### DIFF
--- a/rosflight_io/include/rosflight_io/rosflight_io.hpp
+++ b/rosflight_io/include/rosflight_io/rosflight_io.hpp
@@ -485,6 +485,18 @@ private:
    */
   bool rebootToBootloaderSrvCallback(const std_srvs::srv::Trigger::Request::SharedPtr & req,
                                      const std_srvs::srv::Trigger::Response::SharedPtr & res);
+  /**
+   * @brief "all_params_received" service callback.
+   *
+   * This function is called anytime the "all_params_received" ROS service is called. It returns
+   * true if all the parameters have been received from the firmware.
+   *
+   * @param req ROS Trigger service request.
+   * @param res ROS Trigger service response.
+   * @return True
+   */
+  bool checkIfAllParamsReceivedCallback(const std_srvs::srv::Trigger::Request::SharedPtr & req,
+                                        const std_srvs::srv::Trigger::Response::SharedPtr & res);
 
   // timer callbacks
   /**
@@ -545,8 +557,12 @@ private:
   /// "external_attitude" ROS topic subscription.
   rclcpp::Subscription<rosflight_msgs::msg::Attitude>::SharedPtr extatt_sub_;
 
-  /// "unsaved_params" ROS topic publisher.
+  /// "status/unsaved_params" ROS topic publisher.
   rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr unsaved_params_pub_;
+  /// "status/rosflight_errors" ROS topic publisher.
+  rclcpp::Publisher<rosflight_msgs::msg::Error>::SharedPtr error_pub_;
+  /// "status/params_changed" ROS topic publisher.
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr params_changed_pub_;
   /// "imu/data" ROS topic publisher.
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_pub_;
   /// "imu/temperature" ROS topic publisher.
@@ -575,8 +591,6 @@ private:
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr version_pub_;
   /// "lidar" ROS topic publisher.
   rclcpp::Publisher<sensor_msgs::msg::Range>::SharedPtr lidar_pub_;
-  /// "rosflight_errors" ROS topic publisher.
-  rclcpp::Publisher<rosflight_msgs::msg::Error>::SharedPtr error_pub_;
   /// "battery" ROS topic publisher.
   rclcpp::Publisher<rosflight_msgs::msg::BatteryStatus>::SharedPtr battery_status_pub_;
 
@@ -602,6 +616,8 @@ private:
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr reboot_srv_;
   /// "reboot_to_bootloader" ROS service.
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr reboot_bootloader_srv_;
+  /// "all_params_received" ROS service.
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr check_if_all_params_received_srv_;
 
   /// ROS timer for param requests.
   rclcpp::TimerBase::SharedPtr param_timer_;

--- a/rosflight_io/src/rosflight_io.cpp
+++ b/rosflight_io/src/rosflight_io.cpp
@@ -73,11 +73,13 @@ ROSflightIO::ROSflightIO()
   rclcpp::QoS qos_transient_local_1_(1);
   qos_transient_local_1_.transient_local();
   unsaved_params_pub_ =
-    this->create_publisher<std_msgs::msg::Bool>("unsaved_params", qos_transient_local_1_);
+    this->create_publisher<std_msgs::msg::Bool>("status/unsaved_params", qos_transient_local_1_);
   rclcpp::QoS qos_transient_local_5_(5); // A relatively large queue so all messages get through
   qos_transient_local_5_.transient_local();
   error_pub_ =
-    this->create_publisher<rosflight_msgs::msg::Error>("rosflight_errors", qos_transient_local_5_);
+    this->create_publisher<rosflight_msgs::msg::Error>("status/rosflight_errors", qos_transient_local_5_);
+  params_changed_pub_ =
+    this->create_publisher<std_msgs::msg::Bool>("status/params_changed", 1);
 
   param_get_srv_ = this->create_service<rosflight_msgs::srv::ParamGet>(
     "param_get",
@@ -113,6 +115,10 @@ ROSflightIO::ROSflightIO()
   reboot_bootloader_srv_ = this->create_service<std_srvs::srv::Trigger>(
     "reboot_to_bootloader",
     std::bind(&ROSflightIO::rebootToBootloaderSrvCallback, this, std::placeholders::_1,
+              std::placeholders::_2));
+  check_if_all_params_received_srv_ = this->create_service<std_srvs::srv::Trigger>(
+    "all_params_received",
+    std::bind(&ROSflightIO::checkIfAllParamsReceivedCallback, this, std::placeholders::_1,
               std::placeholders::_2));
 
   this->declare_parameter("udp", rclcpp::PARAMETER_BOOL);
@@ -156,6 +162,7 @@ ROSflightIO::ROSflightIO()
 
   // request the param list
   mavrosflight_->param.request_params();
+  // TODO: Do these need to be changed to node timers instead of wall timers?
   param_timer_ =
     this->create_wall_timer(std::chrono::seconds(PARAMETER_PERIOD),
                             std::bind(&ROSflightIO::paramTimerCallback, this), nullptr);
@@ -263,6 +270,13 @@ void ROSflightIO::on_new_param_received(std::string name, double value)
 void ROSflightIO::on_param_value_updated(std::string name, double value)
 {
   RCLCPP_INFO(this->get_logger(), "Parameter %s has new value %g", name.c_str(), value);
+
+  if (mavrosflight_->param.got_all_params()) {
+    // Send message that params have changed
+    std_msgs::msg::Bool params_changed;
+    params_changed.data = true;
+    params_changed_pub_->publish(params_changed);
+  }
 }
 
 void ROSflightIO::on_params_saved_change(bool unsaved_changes)
@@ -727,6 +741,7 @@ void ROSflightIO::handle_battery_status_msg(const mavlink_message_t & msg)
 
   battery_status_pub_->publish(battery_status_message);
 }
+
 void ROSflightIO::handle_rosflight_gnss_msg(const mavlink_message_t & msg)
 {
   mavlink_rosflight_gnss_t gnss;
@@ -952,6 +967,18 @@ bool ROSflightIO::rebootToBootloaderSrvCallback(
   mavlink_msg_rosflight_cmd_pack(1, 50, &msg, ROSFLIGHT_CMD_REBOOT_TO_BOOTLOADER);
   mavrosflight_->comm.send_message(msg);
   res->success = true;
+  return true;
+}
+
+bool ROSflightIO::checkIfAllParamsReceivedCallback(
+  const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  const std_srvs::srv::Trigger::Response::SharedPtr & res)
+{
+  res->success = mavrosflight_->param.got_all_params();
+  res->message = "Not all params recieved from firmware.";
+  if (res->success) {
+    res->message = "All params recieved from firmware.";
+  }
   return true;
 }
 

--- a/rosflight_sim/simulators/standalone_sim/CMakeLists.txt
+++ b/rosflight_sim/simulators/standalone_sim/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 # Find packages
 find_package(ament_cmake REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rosflight_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
@@ -71,6 +72,7 @@ target_include_directories(multirotor_forces_and_moments
   PRIVATE
     ../../include
     include)
+target_link_libraries(multirotor_forces_and_moments Eigen3::Eigen)
 ament_target_dependencies(multirotor_forces_and_moments
   rclcpp
   std_srvs
@@ -88,8 +90,9 @@ add_executable(fixedwing_forces_and_moments
   src/fixedwing_forces_and_moments.cpp)
 target_include_directories(fixedwing_forces_and_moments
   PRIVATE
-    include
-    simulators/standalone_sim/include)
+    ../../include
+    include)
+target_link_libraries(fixedwing_forces_and_moments Eigen3::Eigen)
 ament_target_dependencies(fixedwing_forces_and_moments
   rclcpp
   std_srvs

--- a/rosflight_sim/simulators/standalone_sim/include/fixedwing_forces_and_moments.hpp
+++ b/rosflight_sim/simulators/standalone_sim/include/fixedwing_forces_and_moments.hpp
@@ -158,7 +158,13 @@ public:
    */
   geometry_msgs::msg::WrenchStamped update_forces_and_torques(rosflight_msgs::msg::SimState x,
                                                               geometry_msgs::msg::Vector3Stamped wind,
-                                                              std::array<uint16_t, 14> act_cmds) override;
+                                                              std::array<uint16_t, NUM_TOTAL_OUTPUTS> act_cmds) override;
+
+  /**
+  * @brief Queries rosflight_io for any changed parameters
+  */
+  void get_firmware_parameters() override;
+
 };
 
 } // namespace rosflight_sim

--- a/rosflight_sim/simulators/standalone_sim/include/multirotor_forces_and_moments.hpp
+++ b/rosflight_sim/simulators/standalone_sim/include/multirotor_forces_and_moments.hpp
@@ -36,6 +36,7 @@
 #ifndef ROSFLIGHT_SIM_MULTIROTOR_FORCES_AND_MOMENTS_H
 #define ROSFLIGHT_SIM_MULTIROTOR_FORCES_AND_MOMENTS_H
 
+#include <cmath>
 #include <cstdint>
 
 #include <Eigen/Core>
@@ -101,10 +102,6 @@ private:
   void declare_multirotor_params();
 
 public:
-  /**
-   * @param node ROS2 node to obtain parameters from. Usually the node provided by the Gazebo model
-   * plugin.
-   */
   explicit Multirotor();
   ~Multirotor();
 
@@ -117,7 +114,12 @@ public:
    */
   geometry_msgs::msg::WrenchStamped update_forces_and_torques(rosflight_msgs::msg::SimState x,
                                                               geometry_msgs::msg::Vector3Stamped wind,
-                                                              std::array<uint16_t, 14> act_cmds) override;
+                                                              std::array<uint16_t, NUM_TOTAL_OUTPUTS> act_cmds) override;
+
+  /**
+  * @brief Queries rosflight_io for any changed parameters
+  */
+  void get_firmware_parameters() override;
 };
 
 } // namespace rosflight_sim

--- a/rosflight_sim/simulators/standalone_sim/src/standalone_dynamics.cpp
+++ b/rosflight_sim/simulators/standalone_sim/src/standalone_dynamics.cpp
@@ -33,8 +33,6 @@
 
 #include "standalone_dynamics.hpp"
 
-#include <iostream>
-
 namespace rosflight_sim
 {
 

--- a/rosflight_sim/src/forces_and_moments_interface.cpp
+++ b/rosflight_sim/src/forces_and_moments_interface.cpp
@@ -39,10 +39,14 @@ namespace rosflight_sim
 {
 
 ForcesAndMomentsInterface::ForcesAndMomentsInterface()
-  : rclcpp::Node("forces_and_moments")
+  : rclcpp::Node("mav_forces_and_moments")
+  , primary_mixing_matrix_(Eigen::Matrix<double, 6, NUM_MIXER_OUTPUTS>::Zero())
+  , secondary_mixing_matrix_(Eigen::Matrix<double, 6, NUM_MIXER_OUTPUTS>::Zero())
+  , mixer_header_vals_(Eigen::Matrix<int, 1, NUM_MIXER_OUTPUTS>::Zero())
 {
   // Note that we don't define the parameter callback routine here.
   // This is so that implementation-specific details can be included there.
+  this->declare_parameter("invert_mixing_matrix", true);
 
   // Define ROS interfaces
   forces_moments_pub_ = this->create_publisher<geometry_msgs::msg::WrenchStamped>("/forces_and_moments", 1);
@@ -52,6 +56,21 @@ ForcesAndMomentsInterface::ForcesAndMomentsInterface()
     "sim/wind_truth", 1, std::bind(&ForcesAndMomentsInterface::wind_callback, this, std::placeholders::_1));
   firware_out_sub_ = this->create_subscription<rosflight_msgs::msg::PwmOutput>(
     "sim/pwm_output", 1, std::bind(&ForcesAndMomentsInterface::firmware_output_callback, this, std::placeholders::_1));
+
+  sub_cb_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  // TODO:_Does this need to be a member variable?
+  rclcpp::SubscriptionOptions options;
+  options.callback_group = sub_cb_group_;
+  params_changed_sub_ = this->create_subscription<std_msgs::msg::Bool>(
+    "status/params_changed", 1, std::bind(&ForcesAndMomentsInterface::params_changed_callback, this, std::placeholders::_1), options);
+
+  // Service clients
+  client_cb_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  firmware_param_get_client_ = this->create_client<rosflight_msgs::srv::ParamGet>("param_get", rmw_qos_profile_services_default, client_cb_group_);
+  firmware_check_param_client_ = this->create_client<std_srvs::srv::Trigger>("all_params_received", rmw_qos_profile_services_default, client_cb_group_);
+
+  // Request mixer values on boot
+  do_initialize_parameters_ = true;
 }
 
 void ForcesAndMomentsInterface::state_callback(const rosflight_msgs::msg::SimState & msg)
@@ -66,11 +85,168 @@ void ForcesAndMomentsInterface::wind_callback(const geometry_msgs::msg::Vector3S
 
 void ForcesAndMomentsInterface::firmware_output_callback(const rosflight_msgs::msg::PwmOutput & msg)
 {
+  if (do_initialize_parameters_) {
+    std_msgs::msg::Bool msg;
+    msg.data = true;
+    params_changed_callback(msg);
+    do_initialize_parameters_ = false;
+  }
+
   // Update the forces and moments
   geometry_msgs::msg::WrenchStamped forces_moments = update_forces_and_torques(current_state_, current_wind_, msg.values);
 
   // Publish forces and moments
   forces_moments_pub_->publish(forces_moments);
+}
+
+void ForcesAndMomentsInterface::params_changed_callback(const std_msgs::msg::Bool & msg)
+{
+  // If true, load firmware parameters from rosflight_io
+  if (msg.data) {
+    // First check if rosflight_io has all the parameters. Otherwise, all the param_get service calls will be incorrect
+    if (!send_check_params_service_to_firmware()) {
+      return;
+    }
+
+    // Get the mixer parameters from the firmware
+    get_mixer_firmware_parameters();
+
+    // Don't invert fixedwing mixers, since the fixedwing mixers were never inverted by firmware.
+    // Don't invert if primary mixer is out of range
+    if (primary_mixer_ != 9 &&
+        primary_mixer_ != 10 &&
+        primary_mixer_ < 12 &&
+        (primary_mixer_ == 11 &&
+         this->get_parameter("invert_mixing_matrix").as_bool())
+       ) {
+      // Invert the mixer, since the mixer stored in the firmware parameters
+      // is M^{-1} as defined in Small Unmanned Aircraft chapter 14, inverting it here gives M.
+      invert_matrix(primary_mixing_matrix_);
+      invert_matrix(secondary_mixing_matrix_);
+    }
+
+    // Get any implementation-specific parameters
+    get_firmware_parameters();
+  }
+}
+
+void ForcesAndMomentsInterface::get_mixer_firmware_parameters()
+{
+  // Get the primary and secondary mixer type
+  std::string param_name = "PRIMARY_MIXER";
+  double param_val = send_get_param_service_to_firmware(param_name);
+  primary_mixer_ = (int) param_val;
+
+  param_name = "SECONDARY_MIXER";
+  param_val = send_get_param_service_to_firmware(param_name);
+  secondary_mixer_ = (int) param_val;
+
+  // Get the relevant mixer header parameters
+  for (int i=0; i<NUM_MIXER_OUTPUTS; ++i) {
+    param_name = "PRI_MIXER_OUT_" + std::to_string(i);
+    param_val = send_get_param_service_to_firmware(param_name);
+    mixer_header_vals_(i) = (int) param_val;
+  }
+
+  // Get the mixer matrix parameters and relevant header parameters
+  for (int i=0; i<6; ++i) {
+    for (int j=0; j<NUM_MIXER_OUTPUTS; ++j) {
+      param_name = "PRI_MIXER_" + std::to_string(i) + "_" + std::to_string(j);
+      param_val = send_get_param_service_to_firmware(param_name);
+      primary_mixing_matrix_(i,j) = param_val;
+
+      param_name = "SEC_MIXER_" + std::to_string(i) + "_" + std::to_string(j);
+      param_val = send_get_param_service_to_firmware(param_name);
+      secondary_mixing_matrix_(i,j) = param_val;
+    }
+  }
+
+  RCLCPP_INFO_STREAM(this->get_logger(), "Primary mixer used in sim:\n" << primary_mixing_matrix_);
+  RCLCPP_INFO_STREAM(this->get_logger(), "Secondary mixer used in sim:\n" << secondary_mixing_matrix_);
+  RCLCPP_INFO_STREAM(this->get_logger(), "Mixer headers used in sim:\n" << mixer_header_vals_);
+}
+
+double ForcesAndMomentsInterface::send_get_param_service_to_firmware(std::string param_name)
+{
+  // Call rosflight_io service
+  // check to see if service exists
+  if (!firmware_param_get_client_->wait_for_service(std::chrono::milliseconds(500))) {
+    RCLCPP_WARN_STREAM(this->get_logger(), "Firmware \"param_get\" service not available! Unable to get " + param_name + " parameter! Value will be zero");
+    return 0.0;
+  }
+
+  // Fill in request object
+  auto req = std::make_shared<rosflight_msgs::srv::ParamGet::Request>();
+  req->name = param_name;
+
+  // Send service request and wait for response
+  auto result_future = firmware_param_get_client_->async_send_request(req);
+  std::future_status status = result_future.wait_for(std::chrono::milliseconds(5000));
+
+  // Check if everything finished properly
+  if (status != std::future_status::ready) {
+    RCLCPP_WARN_STREAM(this->get_logger(), "Firmware param_get service timed out! " + param_name + " value will be zero");
+    return 0.0;
+  }
+
+  rosflight_msgs::srv::ParamGet::Response::SharedPtr response = result_future.get(); // Can only get it once
+
+  if (!response->exists) {
+    RCLCPP_WARN_STREAM(this->get_logger(), "Firmware parameter " + param_name + " does not exist! Value will be zero");
+    return 0.0;
+  }
+
+  return response->value;
+}
+
+bool ForcesAndMomentsInterface::send_check_params_service_to_firmware()
+{
+  // Call rosflight_io service
+  // check to see if service exists
+  if (!firmware_check_param_client_->wait_for_service(std::chrono::milliseconds(500))) {
+    RCLCPP_WARN_STREAM(this->get_logger(), "Firmware \"all_params_received\" service not available!");
+    return false;
+  }
+
+  // Fill in request object
+  auto req = std::make_shared<std_srvs::srv::Trigger::Request>();
+
+  // Send service request and wait for response
+  auto result_future = firmware_check_param_client_->async_send_request(req);
+  std::future_status status = result_future.wait_for(std::chrono::milliseconds(5000));
+
+  // Check if everything finished properly
+  if (status != std::future_status::ready) {
+    RCLCPP_WARN_STREAM(this->get_logger(), "Firmware all_params_received service timed out!");
+    return false;
+  }
+
+  std_srvs::srv::Trigger::Response::SharedPtr response = result_future.get(); // Can only get it once
+  return response->success;
+}
+
+void ForcesAndMomentsInterface::invert_matrix(Eigen::Matrix<double, 6, NUM_MIXER_OUTPUTS> &mixer_to_invert)
+{
+  // Calculate the pseudoinverse of the mixing matrix using the SVD
+  Eigen::JacobiSVD<Eigen::Matrix<double, 6, NUM_MIXER_OUTPUTS>> svd(
+    mixer_to_invert,
+    Eigen::FullPivHouseholderQRPreconditioner | Eigen::ComputeFullU | Eigen::ComputeFullV);
+  Eigen::Matrix<double, NUM_MIXER_OUTPUTS, 6> Sig;
+  Sig.setZero();
+
+  // Avoid dividing by zero in the Sigma matrix
+  if (svd.singularValues()[0] != 0.0) { Sig(0, 0) = 1.0 / svd.singularValues()[0]; }
+  if (svd.singularValues()[1] != 0.0) { Sig(1, 1) = 1.0 / svd.singularValues()[1]; }
+  if (svd.singularValues()[2] != 0.0) { Sig(2, 2) = 1.0 / svd.singularValues()[2]; }
+  if (svd.singularValues()[3] != 0.0) { Sig(3, 3) = 1.0 / svd.singularValues()[3]; }
+  if (svd.singularValues()[4] != 0.0) { Sig(4, 4) = 1.0 / svd.singularValues()[4]; }
+  if (svd.singularValues()[5] != 0.0) { Sig(5, 5) = 1.0 / svd.singularValues()[5]; }
+
+  // Pseudoinverse of the mixing matrix
+  Eigen::Matrix<double, NUM_MIXER_OUTPUTS, 6> mixer_pinv = svd.matrixV() * Sig * svd.matrixU().transpose();
+
+  // Save the inverted matrix
+  mixer_to_invert = mixer_pinv.transpose();
 }
 
 } // namespace rosflight_sim


### PR DESCRIPTION
This PR enables other nodes to query `rosflight_io` for the current firmware parameters. 

## Motivation
This is needed because some implementations of the forces and moments need to know the mixer parameters to accurately unmix and compute the forces and moments. This is apparent when doing vtail mixing for a fixedwing, since our forces and moments equations assume the standard tail configuration. Thus, we either have to unmix the commands (to get back to servo commands that map to the standard tail configuration) or hard code a new forces and moments implementation. This PR allows the forces and moments node to query `rosflight_io` for the mixer parameters so it can use them internally.

Note that this also enables synching the parameters between the firmware and other nodes.

## What I did
`rosflight_io`:
- Added publisher to publish a bool when it detects that the firmware parameters have new values. 
`forces_and_moments`:
- On initialization in the `forces_and_moments_interface` module, it queries `rosflight_io` for all the parameters it needs. It also queries when it the subscription callback to `rosflight_io`'s publisher gets called.
- Added a virtual function that allows derived classes to query other parameters on initialization as needed.

## Important notes:
- A lot of the complexity here is because we don't want `rosflight_io` to know if anyone else needs parameters, since then it would know if it is in sim or not. We also don't know when nodes start up, so we need nodes to query `rosflight_io` on both initialization _and_ a subscription callback.
- Currently the only time we need this functionality is for the vtail configuration. Essentially, it is only really useful (right now) for unmixing servo commands. Motor commands are easily converted to forces and moments since there is a one-to-one mapping between an output channel and a motor, and we can compute the forces and moments generated by that motor. Note that this does depend on the frame configuration and how the motors are aligned. In `multirotor_forces_and_moments.cpp` we assume that they are all planar, but we do need information such as where the motors are located. The mixer (sometimes, but not always -- i.e. canned vs custom mixer) will also use this same frame information, so perhaps there is a way to use the mixing matrix in the `multirotor_forces_and_moments.cpp` file. This PR is a good initial step.