### PR TITLE
Expose firmware control gains to ROS2 parameter interface

### DIFF
--- a/rosflight_io/include/rosflight_io/rosflight_io.hpp
+++ b/rosflight_io/include/rosflight_io/rosflight_io.hpp
@@ -43,6 +43,7 @@
 
 #include <map>
 #include <string>
+#include <set>
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -550,6 +551,22 @@ private:
    */
   rclcpp::Time fcu_time_to_ros_time(std::chrono::nanoseconds fcu_time);
 
+  /**
+  * @brief Declares all the ROS2 parameters for the node.
+  */
+  void declare_parameters();
+  /**
+   * @brief loads parameters from firmware to ROS2 on boot (when all params have been received)
+   * as a convenience for easy read/write access from ROS2
+   */
+  void load_convenience_parameters();
+  /**
+  * @brief Handles any parameter changes to the node.
+  *
+  * @param parameters Vector of rclcpp::Parameters passed by ROS2 when params are changed.
+  */
+  rcl_interfaces::msg::SetParametersResult parameters_callback(const std::vector<rclcpp::Parameter> & parameters);
+
   /// "command" ROS topic subscription.
   rclcpp::Subscription<rosflight_msgs::msg::Command>::SharedPtr command_sub_;
   /// "aux_command" ROS topic subscription.
@@ -618,6 +635,10 @@ private:
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr reboot_bootloader_srv_;
   /// "all_params_received" ROS service.
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr check_if_all_params_received_srv_;
+
+  /// Handle for the ROS2 parameter callback
+  OnSetParametersCallbackHandle::SharedPtr parameter_callback_handle_;
+  std::set<std::string> convenience_parameters_;
 
   /// ROS timer for param requests.
   rclcpp::TimerBase::SharedPtr param_timer_;

--- a/rosflight_io/include/rosflight_io/rosflight_io.hpp
+++ b/rosflight_io/include/rosflight_io/rosflight_io.hpp
@@ -43,7 +43,7 @@
 
 #include <map>
 #include <string>
-#include <set>
+#include <unordered_set>
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -638,7 +638,7 @@ private:
 
   /// Handle for the ROS2 parameter callback
   OnSetParametersCallbackHandle::SharedPtr parameter_callback_handle_;
-  std::set<std::string> convenience_parameters_;
+  std::unordered_set<std::string> convenience_parameters_;
 
   /// ROS timer for param requests.
   rclcpp::TimerBase::SharedPtr param_timer_;

--- a/rosflight_io/src/rosflight_io.cpp
+++ b/rosflight_io/src/rosflight_io.cpp
@@ -226,19 +226,19 @@ rcl_interfaces::msg::SetParametersResult
 ROSflightIO::parameters_callback(const std::vector<rclcpp::Parameter> & parameters)
 {
   rcl_interfaces::msg::SetParametersResult result;
-  result.successful = false;
-  result.reason = "One of the parameters is not a parameter of ROSflightIO.";
+  result.successful = true;
 
   for (const auto & param : parameters) {
     std::string name = param.get_name();
     if (convenience_parameters_.count(name) != 0) {
       double value;
       if (!mavrosflight_->param.get_param_value(name, &value)) {
+        result.successful = false;
         result.reason = "Parameter " + name + " does not exist in the firmware.";
         return result;
       }
 
-      if (value == param.as_double()) {
+      if (abs(value - param.as_double()) < 1e-6) {
         result.reason = "Parameter is already set with that value!";
         result.successful = true;
       } else {

--- a/rosflight_io/src/rosflight_io.cpp
+++ b/rosflight_io/src/rosflight_io.cpp
@@ -217,7 +217,7 @@ void ROSflightIO::declare_parameters()
     "PID_PITCH_ANG_I",
     "PID_PITCH_ANG_D"
   };
-  for (auto param : convenience_parameters_) {
+  for (const auto& param : convenience_parameters_) {
     this->declare_parameter(param, rclcpp::PARAMETER_DOUBLE);
   }
 }
@@ -262,9 +262,12 @@ void ROSflightIO::load_convenience_parameters()
 {
   // Load any parameters from the firmware into the ROS2 parameters for easy read and write access.
   double value;
-  for (auto param : convenience_parameters_) {
-    mavrosflight_->param.get_param_value(param, &value);
-    this->set_parameter(rclcpp::Parameter(param, value));
+  for (const auto& param : convenience_parameters_) {
+    if (mavrosflight_->param.get_param_value(param, &value)) {
+      this->set_parameter(rclcpp::Parameter(param, value));
+    } else {
+      RCLCPP_WARN(this->get_logger(), "Failed to get parameter '%s' from the firmware!", param.c_str());
+    }
   }
 }
 

--- a/rosflight_sim/simulators/standalone_sim/launch/multirotor_standalone.launch.py
+++ b/rosflight_sim/simulators/standalone_sim/launch/multirotor_standalone.launch.py
@@ -23,7 +23,7 @@ def generate_launch_description():
     # Declare launch arguments
     use_sim_time_arg = DeclareLaunchArgument(
         "use_sim_time",
-        default_value="true",
+        default_value="false",
         description="Whether the nodes will use sim time or not"
     )
     use_sim_time = LaunchConfiguration('use_sim_time')


### PR DESCRIPTION
This PR exposes firmware gains to the ROS2 parameter interface for the ROSflight_io node. This makes it really easy to change the parameters, useful for parameter tuning. Before, we had to change the gains and other parameters via service call.

Specifically, I added a std::set that holds a list of user-defined parameters that we care about exposing. Right now, it is only controller gains. Gains can still be edited through the `rosflight_msgs/srv/ParamSet` service call, and will automatically be synced with the ROS2 gains.

Also note that on startup, once all the params have been received by `rosflight_io`, it loads the convenience parameters to the ROS2 parameters, handling the case where the parameters were saved to the firmware memory.