### PR TITLE
fix: enabled compiling on Jazzy

### DIFF
--- a/rosflight_sim/package.xml
+++ b/rosflight_sim/package.xml
@@ -24,11 +24,11 @@
   <depend>rclcpp</depend>
   <depend>rclpy</depend>
 
-  <depend>gazebo_dev</depend>
-  <depend>gazebo_plugins</depend>
-  <depend>gazebo_ros</depend>
-  <depend>gazebo</depend>
-  <depend>xacro</depend>
+  <depend condition="$ROS_DISTRO == 'humble'">gazebo_dev</depend>
+  <depend condition="$ROS_DISTRO == 'humble'">gazebo_plugins</depend>
+  <depend condition="$ROS_DISTRO == 'humble'">gazebo_ros</depend>
+  <depend condition="$ROS_DISTRO == 'humble'">gazebo</depend>
+  <depend condition="$ROS_DISTRO == 'humble'">xacro</depend>
 
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/rosflight_sim/simulators/gazebo_sim/CMakeLists.txt
+++ b/rosflight_sim/simulators/gazebo_sim/CMakeLists.txt
@@ -17,7 +17,7 @@ endif(NOT CMAKE_BUILD_TYPE)
 # Since Gazebo doesn't have an arm64 target, skip this package if gazebo is not found
 find_package(gazebo_ros QUIET)
 if(NOT gazebo_FOUND)
-  install(CODE "message(\"Gazebo not found, skipping ${PROJECT_NAME}\")")
+  install(CODE "message(\"Gazebo not found, skipping Gazebo sim")
   return()
 endif()
 

--- a/rosflight_sim/simulators/standalone_sim/CMakeLists.txt
+++ b/rosflight_sim/simulators/standalone_sim/CMakeLists.txt
@@ -34,6 +34,7 @@ target_include_directories(standalone_viz_transcriber
   PRIVATE
     include)
 ament_target_dependencies(standalone_viz_transcriber
+  ament_index_cpp
   geometry_msgs
   rclcpp
   rosflight_msgs


### PR DESCRIPTION
Currently ROSflight does not compile on the latest LTS.

This makes Gazebo dependencies install only on Humble (since Gazebo classic is not on Jazzy) and adds a necessary dependency to CMAKE, as the installation location of some ament files changed and cannot be included the old way: https://github.com/ament/ament_index/issues/84